### PR TITLE
Fix copy-paste error in gauge_force_imp_gpu.c

### DIFF
--- a/generic/gauge_force_imp_gpu.c
+++ b/generic/gauge_force_imp_gpu.c
@@ -53,7 +53,7 @@ void imp_gauge_force_gpu(Real eps, field_offset mom_off)
   qudaGaugeForce(PRECISION,num_loop_types,quda_loop_coeff,eb3,links,momentum);
 
   FORALLSITES_OMP(i,st,private(dir,j)){
-    for(dir=XUP; dir<TUP; ++dir){
+    for(dir=XUP; dir<=TUP; ++dir){
       for(j=0; j<10; ++j){
 	((Real*)&(st->mom[dir]))[j] += ((Real*)(momentum + 4*i+dir))[j];
       }


### PR DESCRIPTION
This caused the gauge force to evaluate incorrectly when using QUDA.