### PR TITLE
Update make_lattice.c

### DIFF
--- a/generic/make_lattice.c
+++ b/generic/make_lattice.c
@@ -23,6 +23,7 @@ void make_lattice(){
 	       (double)sites_on_node * sizeof(site)/1e6);
 
 #ifdef HAVE_QUDA
+  initialize_quda();
   lattice = (site *)qudaAllocatePinned( sites_on_node * sizeof(site) );
 #else
   lattice = (site *)malloc( sites_on_node * sizeof(site) );


### PR DESCRIPTION
This change ensures that QUDA is initialized prior to allocating pinned memory.  Without doing this, when GPU-pinned memory is allocated, each MPI processes on a node will create a distinct CUDA context on the default GPU (i.e., GPU 0); this results in ~150 MiB wasted memory on GPU 0 that becomes significant if running 8 processes (e.g., 8 GPUs in a node).  Since `initialize_quda` will assign the relevant GPU to each process, creating the CUDA context on the correct GPU, this removes that wasted memory.