### PR TITLE
Allow QUDA to handle rephase calls

### DIFF
--- a/generic/gauge_force_imp_gpu.c
+++ b/generic/gauge_force_imp_gpu.c
@@ -35,7 +35,7 @@ void imp_gauge_force_gpu(Real eps, field_offset mom_off)
   for(i=0; i<num_loop_types; ++i) quda_loop_coeff[i] = loop_coeff[i][0];
 
   QudaMILCSiteArg_t arg = newQudaMILCSiteArg();
-  qudaGaugeForce(MILC_PRECISION,num_loop_types,quda_loop_coeff,eb3,&arg);
+  qudaGaugeForcePhased(MILC_PRECISION,num_loop_types,quda_loop_coeff,eb3,&arg, phases_in);
 
   free(quda_loop_coeff);
 

--- a/generic/reunitarize2.c
+++ b/generic/reunitarize2.c
@@ -217,7 +217,7 @@ void reunitarize_gpu() {
 #endif
 
   QudaMILCSiteArg_t arg = newQudaMILCSiteArg();
-  qudaUnitarizeSU3(MILC_PRECISION, TOLERANCE, &arg);
+  qudaUnitarizeSU3Phased(MILC_PRECISION, TOLERANCE, &arg, phases_in);
 
 #ifdef GFTIME
   dtime += dclock();
@@ -283,13 +283,17 @@ void reunitarize() {
      if Schroedinger functional boundary conditions are enabled */
 #ifdef SCHROED_FUN
   node0_printf("%s not supported on GPU, using CPU fallback\n", __func__);
+  rephase(OFF)
   reunitarize_cpu();
+  rephase(ON)
 #else
   reunitarize_gpu();
 #endif
 
 #else
+  rephase(OFF)
   reunitarize_cpu();
+  rephase(ON)
 #endif
 
 }

--- a/include/generic.h
+++ b/include/generic.h
@@ -300,13 +300,19 @@ void imp_gauge_force_gpu( Real eps, field_offset mom_off );
 
 void imp_gauge_force_qphix( Real eps, field_offset mom_off );
 
+static void imp_gauge_force( Real eps, field_offset mom_off ){
 #ifdef USE_GF_GPU
-#define imp_gauge_force imp_gauge_force_gpu
+	imp_gauge_force_gpu(eps, mom_off);
 #elif USE_GF_QPHIX
-#define imp_gauge_force imp_gauge_force_qphix
+	rephase(OFF);
+	imp_gauge_force_qphix(eps, mom_off);
+	rephase(ON);
 #else
-#define imp_gauge_force imp_gauge_force_cpu
+	rephase(OFF);
+	imp_gauge_force_cpu(eps, mom_off);
+	rephase(ON);
 #endif
+}
 
 /* gauge_stuff.c */
 double imp_gauge_action(void);

--- a/ks_imp_rhmc/update_h_rhmc.c
+++ b/ks_imp_rhmc/update_h_rhmc.c
@@ -19,9 +19,7 @@ int update_h_rhmc( Real eps, su3_vector **multi_x ){
 #endif
   /*  node0_printf("update_h_rhmc:\n"); */
   /* gauge field force */
-  rephase(OFF);
   imp_gauge_force(eps,F_OFFSET(mom));
-  rephase(ON);
   /* fermionic force */
   
   iters = update_h_fermion( eps,  multi_x );
@@ -33,9 +31,7 @@ int update_h_rhmc( Real eps, su3_vector **multi_x ){
 void update_h_gauge( Real eps ){
   /* node0_printf("update_h_gauge:\n");*/
   /* gauge field force */
-  rephase(OFF);
   imp_gauge_force(eps,F_OFFSET(mom));
-  rephase(ON);
 } /* update_h_gauge */
 
 // fermion force update grouping pseudofermions with the same path coeffs

--- a/ks_imp_rhmc/update_rhmc.c
+++ b/ks_imp_rhmc/update_rhmc.c
@@ -316,7 +316,7 @@ int update() {
         /* update U's by half time step to get to even time */
         update_u(epsilon*0.5);
         /* reunitarize the gauge field */
-        rephase( OFF ); reunitarize(); rephase( ON );
+        reunitarize();
         /*TEMP - monitor action*/if(step%4==0)d_action_rhmc(multi_x,sumvec);
       }	/* end loop over microcanonical steps */
     break;
@@ -330,7 +330,7 @@ int update() {
         iters += update_h_rhmc( epsilon, multi_x);
         update_u(0.5*epsilon*lambda);
         /* reunitarize the gauge field */
-        rephase( OFF ); reunitarize(); rephase( ON );
+        reunitarize();
         /*TEMP - monitor action*/ //if(step%4==0)d_action_rhmc(multi_x,sumvec);
       }	/* end loop over microcanonical steps */
     break;
@@ -354,9 +354,7 @@ int update() {
      	    update_u( epsilon*( (2.0)-(1.75+0.5*alpha) ) );
 
             /* reunitarize the gauge field */
-	    rephase( OFF );
             reunitarize();
-	    rephase( ON );
             /*TEMP - monitor action*/ //if(step%6==0)d_action_rhmc(multi_x,sumvec);
         }	/* end loop over microcanonical steps */
     break;
@@ -466,9 +464,7 @@ int update() {
      	    update_u( epsilon*( (2.0)-(11.0/6.0+alpha/3.0) ) );
 
             /* reunitarize the gauge field */
-	    rephase( OFF );
             reunitarize();
-	    rephase( ON );
 #ifdef MILC_GLOBAL_DEBUG
 #ifdef HISQ_REUNITARIZATION_DEBUG
             {
@@ -585,9 +581,7 @@ int update() {
         /* finish */
      	    update_u( epsilon*( (2.0)-(19.0/10.0+alpha/5.0) ) );
         /* reunitarize the gauge field */
-	    rephase( OFF );
             reunitarize();
-	    rephase( ON );
         }
     break;
     case INT_6G1F:
@@ -632,9 +626,7 @@ int update() {
         /* finish */
      	    update_u( epsilon*( (2.0)-(23.0/12.0+alpha/6.0) ) );
         /* reunitarize the gauge field */
-	    rephase( OFF );
             reunitarize();
-	    rephase( ON );
         }
     break;
     case INT_2EPS_3TO1:
@@ -714,7 +706,7 @@ int update() {
     	    update_u(0.5*epsilon*lambda);
 
             /* reunitarize the gauge field */
-	    rephase( OFF ); reunitarize(); rephase( ON );
+	    reunitarize();
             /*TEMP - monitor action*/ //if(step%6==0)d_action_rhmc(multi_x,sumvec);
 
         }	/* end loop over microcanonical steps */

--- a/ks_imp_rhmc/update_u.c
+++ b/ks_imp_rhmc/update_u.c
@@ -34,7 +34,7 @@ void update_u(Real eps){
 #endif
 
   QudaMILCSiteArg_t arg = newQudaMILCSiteArg();
-  qudaUpdateU(MILC_PRECISION, eps, &arg);
+  qudaUpdateUPhased(MILC_PRECISION, eps, &arg, phases_in);
 
 #ifdef GFTIME
   dtime += dclock();


### PR DESCRIPTION
This pull request depends on https://github.com/lattice/quda/pull/1018 being merged first.

It move the rephase(OFF)/(ON) calls for gauge_force and reunitarize into the calls of these functions and skips them for QUDA, so QUDA can take care of removing and applying staggered phases (assuming MILC staggered phase convention and antiperiodic bc).

This is needed to prevent touching the gauge field on the CPU for rephrasing and allows QUDA to keep the gauge field resident.

https://github.com/lattice/quda/pull/1019 adds a first step in this direction and reduces host-device data transfers.

https://github.com/lattice/quda/pull/1018 just adds the necessary calls to QUDA's MILC interface so that MILC can pass on information to QUDA whether phases are applied. This also leads to a small speedup as rephasing on the GPU is faster esp if it is done in places where the gauge field is needed on the GPU anyway and no additional device-host traffic is created.
