### PR TITLE
Update compile_su3_rhmd_hisq_quda helper script for recent Makefile changes

### DIFF
--- a/ks_imp_rhmc/compile_su3_rhmd_hisq_quda.sh
+++ b/ks_imp_rhmc/compile_su3_rhmd_hisq_quda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-MY_CC=mpicc \
-MY_CXX=mpicxx \
+CC=mpicc \
+CXX=mpicxx \
 CUDA_HOME=${PATH_TO_CUDA} \
 QUDA_HOME=${PATH_TO_QUDA} \
 WANTQUDA=true \


### PR DESCRIPTION
This PR does a quick robustness improvement to the QUDA-accelerated RHMD compile helper script, replacing setting `MY_CC` and `MY_CXX` with `CC` and `CXX`.