### PR TITLE
Added PERLMUTTER flag to QUDA compile helpers

### DIFF
--- a/ks_imp_rhmc/compile_su3_rhmd_hisq_quda.sh
+++ b/ks_imp_rhmc/compile_su3_rhmd_hisq_quda.sh
@@ -24,6 +24,11 @@ then
   exit
 fi
 
+if [ -z "$PERLMUTTER" ]
+then
+  export PATH_TO_NVHPCSDK=""
+fi
+
 if [ ! -f "./Makefile" ]
 then
   cp ../Makefile .

--- a/ks_spectrum/compile_ks_spectrum_hisq_quda.sh
+++ b/ks_spectrum/compile_ks_spectrum_hisq_quda.sh
@@ -29,6 +29,11 @@ then
   MG="-DMULTIGRID"
 fi
 
+if [ -z "$PERLMUTTER" ]
+then
+  export PATH_TO_NVHPCSDK=""
+fi
+
 if [ ! -f "./Makefile" ]
 then
   cp ../Makefile .


### PR DESCRIPTION
This PR updates the MILC+QUDA compile helpers to properly support compiling on and off Perlmutter. If the environment variable `PERLMUTTER` is set, MILC will compile with appropriate linkages to the HPC SDK. If `PERLMUTTER` is unset no extra linking will occur.

Alternatively, we might be able to remove the HPCSDK paths/etc from the MILC `Makefile` altogether, based on what I drafted up in https://github.com/lattice/quda/wiki/QUDA-on-Perlmutter . What do you think @detar ?