### PR TITLE
Hotfix patch to Makefile for QUDA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,8 @@ ifeq ($(strip ${WANTQUDA}),true)
   ifeq ($(strip ${WANT_SPIN_TASTE_GPU}),true)
     HAVE_SPIN_TASTE_GPU = true
     CGPU += -DUSE_SPIN_TASTE_QUDA
+  endif
+
   ifeq ($(strip ${WANT_GAUGEFIX_OVR_GPU}),true)
     HAVE_GAUGEFIX_OVR_QUDA = true
     CGPU += -DUSE_GAUGEFIX_OVR_QUDA


### PR DESCRIPTION
Quick hotfix patch adding an `endif` that got lost in the QUDA portion of the Makefile, accidentally introduced here: https://github.com/milc-qcd/milc_qcd/commit/370f843c80c75910366ef64d7d013558ad87e36d