### PR TITLE
Add restrict keyword on dest array in declare_strided_gather

### DIFF
--- a/generic/com_qmp.c
+++ b/generic/com_qmp.c
@@ -1666,7 +1666,7 @@ declare_strided_gather(
 			   neighbor tables */
   int subl,		/* subl of sites whose neighbors we gather.
 			   It is EVENANDODD, if all sublattices are done. */
-  char ** dest)		/* one of the vectors of pointers */
+  char ** __restrict__ dest)/* one of the vectors of pointers */
 {
   int i;	        /* scratch */
   site *s;	        /* scratch pointer to site */


### PR DESCRIPTION
This optimization helps the performance of `declare_strided_gather`.  With the `nvc` compiler (NVIDIA's C compiler), this results in a doubling in performance.