### PR TITLE
Fixes for ks_eigen application

### DIFF
--- a/generic_ks/eigen_stuff_QUDA.c
+++ b/generic_ks/eigen_stuff_QUDA.c
@@ -217,7 +217,8 @@ int ks_eigensolve_QUDA( su3_vector ** eigVec,
   qep.check_interval = 1;
 
   qep.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
-  
+  qep.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;  
+
   qep.use_dagger = QUDA_BOOLEAN_FALSE;
   qep.compute_gamma5 = QUDA_BOOLEAN_FALSE;
   qep.compute_svd = QUDA_BOOLEAN_FALSE;

--- a/generic_ks/eigen_stuff_QUDA.c
+++ b/generic_ks/eigen_stuff_QUDA.c
@@ -100,8 +100,6 @@ int ks_eigensolve_QUDA( su3_vector ** eigVec,
   qip.input_location = QUDA_CPU_FIELD_LOCATION;
   qip.output_location = QUDA_CPU_FIELD_LOCATION;
 
-  qip.sp_pad = 0;
-
   qip.native_blas_lapack = QUDA_BOOLEAN_TRUE;
   
   /* Below are meaningless in eigensovler, but need to be set. */

--- a/include/imp_ferm_links.h
+++ b/include/imp_ferm_links.h
@@ -344,7 +344,7 @@ typedef struct {
   char diagAlg[10];
   int parity; 
 } ks_eigen_param;
-#elif defined(USE_EIG_QUDA)
+#elif defined(USE_EIG_GPU)
 #define ks_eigensolve ks_eigensolve_QUDA
 typedef struct {
   int Nvecs ; /* number of eigenvectors */

--- a/ks_eigen/Make_template
+++ b/ks_eigen/Make_template
@@ -67,6 +67,8 @@ else ifeq ($(strip ${HAVEARPACK}),true)
   ADDDEFINES += -DARPACK
 else ifeq ($(strip ${HAVE_GRID}),true)
   ADDDEFINES += -DGrid_EIG
+else ifeq ($(strip ${HAVE_EIG_QUDA}),true)
+  ADDDEFINES += -DUSE_EIG_GPU
 else
   ADDDEFINES += -DKalkreuter_Ritz
 endif

--- a/ks_eigen/test/su3_eigen_asqtad.QUDA.2.sample-in
+++ b/ks_eigen/test/su3_eigen_asqtad.QUDA.2.sample-in
@@ -35,9 +35,14 @@ eigenval_tolerance 5.0e-13
 
 # Restart Lanczos iteration at Lanczos_max (number of eigenvalues)
 # Lanczos_max >= max_number_of_eigenpairs + 6
+# This corresponds to the QUDA parameter n_kr
+# Typical reasonable choice is ~2*max_number_of_eigenpairs
 Lanczos_max 60
 
 # Chebyshev polynomial (makes region (alpha,beta) smooth and outside diverge. even order gives even function.)
+# Chebyshev_beta should be greater than the largest eigenvalue of the system. For HISQ, a value of 24 should be sufficient
+# Chebyshev_beta=0 prompts QUDA to estimate the largest eigenvalue and use that
+# Chebyshev_alpha should be greater than the largest eigenvalue that is being requested
 Chebyshev_alpha 10
 Chebyshev_beta 100
 Chebyshev_order 20

--- a/ks_eigen/test/su3_eigen_hisq.QUDA.2.sample-in
+++ b/ks_eigen/test/su3_eigen_hisq.QUDA.2.sample-in
@@ -35,9 +35,14 @@ eigenval_tolerance 5.0e-13
 
 # Restart Lanczos iteration at Lanczos_max (number of eigenvalues)
 # Lanczos_max > max_number_of_eigenpairs + 6
+# This corresponds to the QUDA parameter n_kr
+# Typical reasonable choice is ~2*max_number_of_eigenpairs
 Lanczos_max 60
 
 # Chebyshev polynomial (makes region (alpha,beta) smooth and outside diverge. even order gives even function.)
+# Chebyshev_beta should be greater than the largest eigenvalue of the system. For HISQ, a value of 24 should be sufficient
+# Chebyshev_beta=0 prompts QUDA to estimate the largest eigenvalue and use that
+# Chebyshev_alpha should be greater than the largest eigenvalue that is being requested
 Chebyshev_alpha 10
 Chebyshev_beta 100
 Chebyshev_order 20


### PR DESCRIPTION
I think these fixes should only affect the QUDA path of ks_eigen.

There are three minor compilation fixes:

- Changed a leftover USE_EIG_QUDA to USE_EIG_GPU
- Added QUDA option to ks_eigen/Make_template
- Removed deprecated sp_pad from eigen_stuff_QUDA.c. This inversion parameter was removed from QUDA in commit 50864ffde1bd8f46fd4a2a2b2e6d44a5a588e2c2

There is a QUDA interface fix:

- Per Evan Weinberg (@weinbe2), we need to add the use_pc flag to the QudaEigParam structure. This fixes a runtime error about the Hermiticity of the operator

Finally, I added a couple (hopefully useful) comments to the QUDA sample input files.