### PR TITLE
Feature/gb baryon with u1

### DIFF
--- a/generic_u1/generic_u1_includes.h
+++ b/generic_u1/generic_u1_includes.h
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <math.h>
 #include "../include/config.h"  /* Keep this first */
 #include <lattice.h>

--- a/ks_spectrum/Make_template
+++ b/ks_spectrum/Make_template
@@ -228,6 +228,12 @@ ks_spectrum_hisq_gb_baryon_blind_no_sink_links::
 	"DEFINES += -DEIGEN_QIO -DGB_BARYON -DGB_BARYON_MMAP -DBLIND -DNO_SINK_LINKS" \
 	"EXTRA_OBJECTS += ${GB_BARYON_OBJECTS}"
 
+# GB baryon with memory map and blinding with U(1)
+ks_spectrum_hisq_u1_gb_baryon_blind_no_sink_links::
+	${MAKE} -f ${MAKEFILE} target "MYTARGET= $@" ${HISQ_OPTIONS} \
+	"DEFINES += -DEIGEN_QIO -DGB_BARYON -DGB_BARYON_MMAP -DBLIND -DNO_SINK_LINKS -DU1_FIELD" \
+	"EXTRA_OBJECTS += ${GB_BARYON_OBJECTS} ${G_U1_OBJECTS}"
+
 ks_spectrum_hisq_gb_baryon_blind_no_sink_links_no_gauss_links::
 	${MAKE} -f ${MAKEFILE} target "MYTARGET= $@" ${HISQ_OPTIONS} \
         "DEFINES += -DEIGEN_QIO -DGB_BARYON -DGB_BARYON_MMAP -DBLIND -DNO_SINK_LINKS -DNO_GAUSS_SMEAR_LINKS" \


### PR DESCRIPTION
Two very minor changes for GB Baryon compilation with U(1). Previously, I had simply been manually making these changes when I compiled for Omega baryon spectroscopy with U(1) (i.e. EM correction).

The only changes are:

1) Added a new target to ks_spectrum/Make_template
2) Updated generic_u1/generic_u1_includes.h to add "#include <stdint.h>" to resolve compiler "error: unknown type name ‘uint32_t’" during compilation of ../generic_u1/io_u1lat.c. 