### PR TITLE
Makefile: Default to compiling without FFTW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,7 @@ endif
 #----------------------------------------------------------------------
 # 12. FFTW3 Options
 
-WANTFFTW = true
+WANTFFTW ?= false
 
 ifeq ($(strip ${WANTFFTW}),true)
   FFTW ?= ${HOME}/fftw/build-gcc


### PR DESCRIPTION
We (myself, @detar, and @weinbe2) discussed via email some weeks ago that FFTW seems to have inadvertently become a hard requirement for MILC compilation. This simple PR reverts that by setting WANTFFTW?=false instead of WANTFFTW=true.