### PR TITLE
Hotfix/cleanup printfs

### DIFF
--- a/generic/quark_source_sink_op.c
+++ b/generic/quark_source_sink_op.c
@@ -1540,7 +1540,6 @@ static int apply_cov_smear_v(su3_vector *src, quark_source_sink_op *qss_op,
 			     int t0){
 
   /* Smearing is done with coordinate stride 2 to preserve taste */
-  printf("Applying covariant smearing with t0 = %d\n", t0);
   double dtime = start_timing();
 
   int op_type       = qss_op->type;

--- a/generic_ks/fermion_links_hisq_load.c
+++ b/generic_ks/fermion_links_hisq_load.c
@@ -502,11 +502,9 @@ load_X_from_W(info_t *info, fn_links_t *fn, hisq_auxiliary_t *aux,
   double final_flop = 0.0;
   double dtime = -dclock();
 #ifdef USE_FL_GPU
-  printf("Calling load_fatlonglinks_gpu\n"); fflush(stdout);
   load_fatlonglinks_gpu(info, fat, lng, p, aux->W_unitlink);
   final_flop += info->final_flop;
 #else
-  printf("Calling load_fatlinks (cpu)\n"); fflush(stdout);
   load_fatlinks(info, fat, p, aux->W_unitlink );
   final_flop += info->final_flop;
   load_lnglinks(info, lng, p, aux->W_unitlink );

--- a/generic_ks/gb_baryon_3pt.c
+++ b/generic_ks/gb_baryon_3pt.c
@@ -237,7 +237,6 @@ apply_par_xport_3pt(ks_prop_field *dest, ks_prop_field *src,
   destroy_ksp_field(tvec0);
   #endif
   double end = dclock();
-  printf("Time spent in apply_par_xport_3pt with n = %d, dir = (%d, %d, %d): %f sec\n", n, dir[0], dir[1], dir[2], end-start);
   }
 
 #endif // GB_BARYON


### PR DESCRIPTION
This is a very narrow PR that removes 4 print statements, which were probably originally added for debugging purposes, but may not be needed anymore. It may be desirable to remove these if they are no longer needed since they fill up the slurm output file.