### PR TITLE
Revert quicksort to bubble sort in sort_site_list()

### DIFF
--- a/generic/com_qmp.c
+++ b/generic/com_qmp.c
@@ -1052,57 +1052,6 @@ copy_list_switch(comlink *old_compt, int *send_subl)
   return(firstpt);
 }
 
-// Function to swap two addressed values
-static void swap(int *a, int *b)
-{
-    int temp = *a;
-    *a = *b;
-    *b = temp;
-}
-
-/* quicksort adapted from https://gist.github.com/Erniuu/f5d38f1e6b892c70dbac */
-
-// Function to run quicksort on an array of integers
-// l is the leftmost starting index, which begins at 0
-// r is the rightmost starting index, which begins at array length - 1
-static void quicksort(int key[], int arr[], int l, int r)
-{
-    // Base case: No need to sort arrays of length <= 1
-    if (l >= r)
-    {
-        return;
-    }
-    
-    // Choose pivot to be the last element in the subarray
-    int pivot = key[r];
-
-    // Index indicating the "split" between elements smaller than pivot and 
-    // elements greater than pivot
-    int cnt = l;
-
-    // Traverse through array from l to r
-    for (int i = l; i <= r; i++)
-    {
-        // If an element less than or equal to the pivot is found...
-        if (key[i] <= pivot)
-        {
-            // Then swap key[cnt] and key[i] so that the smaller element key[i] 
-            // is to the left of all elements greater than pivot
-            swap(&key[cnt], &key[i]);
-            swap(&arr[cnt], &arr[i]);
-
-            // Make sure to increment cnt so we can keep track of what to swap
-            // key[i] with
-            cnt++;
-        }
-    }
-    
-    // NOTE: cnt is currently at one plus the pivot's index 
-    // (Hence, the cnt-2 when recursively sorting the left side of pivot)
-    quicksort(key, arr, l, cnt-2); // Recursively sort the left side of pivot
-    quicksort(key, arr, cnt, r);   // Recursively sort the right side of pivot
-}
-
 /*
 **  sort a list of sites according to the order of the sites on the
 **  node with which they comunicate
@@ -1135,8 +1084,6 @@ sort_site_list(
     key[j] = node_index(x,y,z,t);
   }
 
-#if 0
-
   /* bubble sort, if this takes too long fix it later */
   for(j = n-1; j>0; j--) {
     flag=0;
@@ -1154,9 +1101,6 @@ sort_site_list(
     }
     if(flag==0)break;
   }
-#else
-  quicksort(key, list, 0, n-1);
-#endif
 
   free(key);
 }


### PR DESCRIPTION
In `generic/com_qmp.c`, the bubble sort in `sort_site_list()` was replaced with a quicksort algorithm five years. Timing tests show that the two are comparable for small lattices and/or single rank, but in general, the bubble sort performs better. Furthermore, the quicksort shows much more variability depending apparently on `node_geometry`, and appears to be unstable. I have seen a case ($128^3 \times 96$ on 4 ranks with 1 2 2 1 `node_geometry`), where the quicksort seemed to hang for 2.5 hours.

Below are timings (in seconds), for various lattice sizes and node geometries. These timings are the "Aggregate time to setup" as reported by MILC. The timing calls were preceded by MPI barriers to ensure reliability of the reported times.

$32^3 \times 48$ with 1 ranks and 16 threads:

	geom	bubble_sort	quick_sort
	1111 1.619427e+00 1.639164e+00

$32^3 \times 48$ with 2 ranks and 16 threads:

	geom	bubble_sort	quick_sort
	1112 1.941438e+00 1.111401e+01
	1121 1.517894e+00 2.083726e+01
	1211 1.525272e+00 2.081216e+01
	2111 1.555645e+00 2.114591e+01

$32^3 \times 48$ with 4 ranks and 16 threads:

	geom	bubble_sort	quick_sort
	1114 7.335889e-01 9.340513e+00
	1122 7.252100e-01 7.746820e+00
	1141 7.243190e-01 2.002365e+01
	1212 7.298560e-01 7.742633e+00
	1221 7.205498e-01 1.041846e+01
	1411 7.217882e-01 2.003768e+01
	2112 7.236161e-01 7.734779e+00
	2121 7.277861e-01 1.038451e+01
	2211 7.330391e-01 1.038051e+01
	4111 7.255461e-01 2.005290e+01

$48^3 \times 64$ with 4 ranks and 16 threads:

	geom	bubble_sort	quick_sort
	1114 2.333113e+00 1.008937e+02
	1122 2.339030e+00 7.044461e+01
	1141 2.334923e+00 1.758457e+02
	1212 2.343771e+00 7.019681e+01
	1221 2.375687e+00 8.924930e+01
	1411 2.348839e+00 1.760400e+02
	2112 2.370212e+00 7.027330e+01
	2121 2.360501e+00 8.919858e+01
	2211 2.367592e+00 8.928261e+01
	4111 2.366314e+00 1.760662e+02

$48^3 \times 64$ with 8 ranks and 8 threads:

	geom	bubble_sort	quick_sort
	1118 1.628307e+00 1.015809e+02
	1124 1.627135e+00 3.699660e+01
	1142 1.645837e+00 5.120450e+01
	1181 1.642371e+00 1.754246e+02
	1214 1.609817e+00 3.693022e+01
	1222 1.638623e+00 2.950006e+01
	1241 1.638780e+00 5.600447e+01
	1412 1.623812e+00 5.121739e+01
	1421 1.627841e+00 5.604948e+01
	1811 1.647310e+00 1.763016e+02
	2114 1.660355e+00 3.691359e+01
	2122 1.651522e+00 2.950401e+01
	2141 1.643160e+00 5.604552e+01
	2212 1.645169e+00 2.954294e+01
	2221 1.663647e+00 3.439474e+01
	2411 1.932185e+00 5.608404e+01
	4112 1.653144e+00 5.122703e+01
	4121 1.655019e+00 5.607794e+01
	4211 1.678389e+00 5.644766e+01
	8111 1.679626e+00 1.756589e+02

These timings show that this change results in a 1-100x speedup of the setup. In the worst case, the setup with bubble sort takes 1.7s whereas the setup with quicksort takes 176s. This is a 100x speedup, but also only a savings of ~3 minutes, which is negligible compared to overall run times. However, I think the change is worth it for the stability alone--given that there are edge cases, as I noted earlier, where the quicksort just hangs.

I ran a test before and after the change and compared computed correlators to ensure no inadvertent change. The results were identical.