### PR TITLE
Feature/reload u1 parallel

### DIFF
--- a/generic_u1/io_u1lat.c
+++ b/generic_u1/io_u1lat.c
@@ -60,7 +60,7 @@
 #define NATURAL_ORDER 0
 
 #undef MAX_BUF_LENGTH
-#define MAX_BUF_LENGTH 4096
+#define MAX_BUF_LENGTH 32768
 
 /* Forward declarations */
 static gauge_file *w_u1_serial_i(char *filename);
@@ -1456,14 +1456,14 @@ static void r_u1_parallel(gauge_file *gf)
   buf_length = 0;
   where_in_buf = 0;
   
-  /* Cycle through nodes, dealing 4 values from each node in sequence.
+  /* Cycle through nodes, dealing 128 values from each node in sequence.
      (We don't know if this pattern is generally optimal.)
 
      It is possible that messages arrive at a node in an order
      different from the order of dealing so we include the site
      coordinates in the message to specify where it goes */
   
-  site_block = 4;
+  site_block = 128;
   for(ksite=0; ksite<sites_on_node; ksite += site_block)
     {
     for(sendnode=0; sendnode<number_of_nodes; sendnode++)

--- a/include/io_u1lat.h
+++ b/include/io_u1lat.h
@@ -44,6 +44,7 @@ void d2f_4cmplx(complex *a,fcomplex *b);
 void cold_u1lat(void);
 gauge_file *setup_u1_output_gauge_file(void);
 gauge_file *r_u1_serial_i(char *filename);
+gauge_file *r_u1_parallel_i(char *filename);
 int read_u1_gauge_hdr(gauge_file *gf, int parallel);
 
 #endif /* _IO_U1LAT_H */


### PR DESCRIPTION
Adding `reload_u1_parallel` capability. Previously, this choice just printed the statement "Can't handle parallel restoring presently!!" and terminated.

I have adjusted the value of `site_block` and `MAX_BUF_LENGTH` based on empirical timing tests of U(1) config loading.

This change results in a significant speedup of U(1) config loading.