### PR TITLE
Feature/batched quda deflation

### DIFF
--- a/generic/milc_to_quda_utilities.c
+++ b/generic/milc_to_quda_utilities.c
@@ -50,6 +50,7 @@ int initialize_quda(void){
 void finalize_quda(void){
 #ifdef USE_CG_GPU
 
+  qudaCleanUpDeflationSpace();
 #ifdef MULTIGRID
   mat_invert_mg_cleanup();
 #endif

--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -133,46 +133,48 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   inv_args.tadpole = u0;
 #endif
 
-  // Setup for deflation on GPU
+  // Setup for deflation (and eigensolve) on GPU
   
   inv_args.tol_restart = param.eigen_param.tol_restart;
   //int parity = param.eigen_param.parity;
   int parity = qic->parity;
-  int blockSize = 1;
+  int blockSize = param.eigen_param.blockSize;
     
   QudaEigParam qep = newQudaEigParam();
   qep.block_size = blockSize;
   qep.eig_type = ( blockSize > 1 ) ? QUDA_EIG_BLK_TR_LANCZOS : QUDA_EIG_TR_LANCZOS;  /* or QUDA_EIG_IR_ARNOLDI, QUDA_EIG_BLK_IR_ARNOLDI */
-  //qep.invert_param = &qip;
-  qep.eig_type = ( blockSize > 1 ) ? QUDA_EIG_BLK_TR_LANCZOS : QUDA_EIG_TR_LANCZOS;  /* or QUDA_EIG_IR_ARNOLDI, QUDA_EIG_BLK_IR_ARNOLDI */
   qep.spectrum = QUDA_SPECTRUM_SR_EIG; /* Smallest Real. Other options: LM, SM, LR, SR, LI, SI */
-  qep.n_conv = param.eigen_param.Nvecs_in;
+  qep.n_conv = param.eigen_param.Nvecs_in; // +2?
   qep.n_ev_deflate = param.eigen_param.Nvecs;
   qep.n_ev = qep.n_conv;
-  qep.n_kr = 2*qep.n_conv;
-  //qep.block_size = blockSize;
-  //qep.tol = tol;
-  //qep.qr_tol = qep.tol;
-  //qep.max_restarts = maxIter;
-  qep.batched_rotate = 0;
+  //qep.n_kr = param.eigen_param.Nkr;
+  qep.n_kr = 2*qep.n_ev;
+  qep.tol = param.eigen_param.tol;
+  qep.qr_tol = qep.tol; // change?
+  qep.max_restarts = param.eigen_param.MaxIter;
   qep.require_convergence = QUDA_BOOLEAN_TRUE;
-  qep.check_interval = 1;
+  qep.check_interval = 10; // change?
   qep.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   qep.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   qep.use_dagger = QUDA_BOOLEAN_FALSE;
   qep.compute_gamma5 = QUDA_BOOLEAN_FALSE;
   qep.compute_svd = QUDA_BOOLEAN_FALSE;
-  qep.use_eigen_qr = QUDA_BOOLEAN_TRUE;
-  //qep.use_poly_acc = QUDA_BOOLEAN_TRUE;
-  //qep.poly_deg = polyDeg;
-  //qep.a_min = aMin;
-  //qep.a_max = aMax;
-  //qep.arpack_check = QUDA_BOOLEAN_FALSE;
-  //strcpy( qep.arpack_logfile, "" );
-  strcpy( qep.vec_infile, param.ks_eigen_startfile );
-  strcpy( qep.vec_outfile, param.ks_eigen_savefile );
-  qep.save_prec = (MILC_PRECISION==2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
+  qep.use_eigen_qr = QUDA_BOOLEAN_TRUE; // change?
+  qep.use_poly_acc = QUDA_BOOLEAN_TRUE;
+  qep.poly_deg = param.eigen_param.poly.norder;
+  qep.a_min = param.eigen_param.poly.minE;
+  qep.a_max = param.eigen_param.poly.maxE;
+  qep.arpack_check = QUDA_BOOLEAN_FALSE;
+  strcpy( qep.vec_infile, param.ks_eigen_startfile ); // auto FRESH if empty?
+  strcpy( qep.vec_outfile, param.ks_eigen_savefile ); // auto forget if empty?
+  //qep.save_prec = (MILC_PRECISION==2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
   qep.io_parity_inflate = QUDA_BOOLEAN_FALSE;
+
+
+  qep.batched_rotate = 20; // add to input parameters
+  qep.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
+  qep.partfile = QUDA_BOOLEAN_TRUE; // add to input parameters
+
     
   inv_args.eig_param = qep;
 

--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -134,25 +134,24 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
 #endif
 
   // Setup for deflation (and eigensolve) on GPU
-  
-  inv_args.tol_restart = param.eigen_param.tol_restart;
-  //int parity = param.eigen_param.parity;
   int parity = qic->parity;
   int blockSize = param.eigen_param.blockSize;
-    
+  static Real previous_mass = -1.0;
+  static bool first_solve=true;
+
   QudaEigParam qep = newQudaEigParam();
   qep.block_size = blockSize;
   qep.eig_type = ( blockSize > 1 ) ? QUDA_EIG_BLK_TR_LANCZOS : QUDA_EIG_TR_LANCZOS;  /* or QUDA_EIG_IR_ARNOLDI, QUDA_EIG_BLK_IR_ARNOLDI */
   qep.spectrum = QUDA_SPECTRUM_SR_EIG; /* Smallest Real. Other options: LM, SM, LR, SR, LI, SI */
-  qep.n_conv = param.eigen_param.Nvecs_in; // +2?
+  qep.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
   qep.n_ev_deflate = param.eigen_param.Nvecs;
   qep.n_ev = qep.n_conv;
-  qep.n_kr = 2*qep.n_ev;
+  qep.n_kr = (param.eigen_param.Nkr < qep.n_ev ) ? 2*qep.n_ev : param.eigen_param.Nkr;
   qep.tol = param.eigen_param.tol;
-  qep.qr_tol = qep.tol; // change?
+  qep.qr_tol = qep.tol;
   qep.max_restarts = param.eigen_param.MaxIter;
   qep.require_convergence = QUDA_BOOLEAN_TRUE;
-  qep.check_interval = 10; // change?
+  qep.check_interval = 10;
   qep.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   qep.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   qep.use_dagger = QUDA_BOOLEAN_FALSE;
@@ -167,25 +166,22 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   strcpy( qep.vec_infile, param.ks_eigen_startfile );
   strcpy( qep.vec_outfile, param.ks_eigen_savefile );
   qep.io_parity_inflate = QUDA_BOOLEAN_FALSE;
-
-  qep.compute_evals_batch_size = 16; // Default is 4
+  qep.compute_evals_batch_size = 16;
   qep.preserve_deflation = QUDA_BOOLEAN_TRUE;
-
-  // If mass changes, eigenvalues need to be recomputed
-  // but no need to recompute on the first solve
-  static Real previous_mass = -1.0;
-  static bool first_solve=true;
   qep.preserve_evals = ( first_solve || fabs(mass - previous_mass) < 1e-6 ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  qep.batched_rotate = param.eigen_param.batchedRotate;
+  qep.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
+  qep.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+
+  inv_args.eig_param = qep;
+  if(param.eigen_param.eigPrec == 2)inv_args.prec_eigensolver = QUDA_DOUBLE_PRECISION;
+  else if(param.eigen_param.eigPrec == 1)inv_args.prec_eigensolver = QUDA_SINGLE_PRECISION;
+  else inv_args.prec_eigensolver = QUDA_HALF_PRECISION;
+
+  inv_args.tol_restart = param.eigen_param.tol_restart;
+
   previous_mass = mass;
   first_solve = false;
-
-  qep.batched_rotate = 20; // add to input parameters
-  qep.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
-  qep.partfile = QUDA_BOOLEAN_TRUE; // add to input parameters
-
-    
-  inv_args.eig_param = qep;
-  inv_args.prec_eigensolver = QUDA_SINGLE_PRECISION;
 
   qudaInvert(MILC_PRECISION,
 	     quda_precision, 
@@ -335,31 +331,30 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
 #endif
 
   // Setup for deflation (and eigensolve) on GPU
-
-  inv_args.tol_restart = param.eigen_param.tol_restart;
-  //int parity = param.eigen_param.parity;
   int parity = qic->parity;
   int blockSize = param.eigen_param.blockSize;
+  static Real previous_mass = -1.0;
+  static bool first_solve=true;
 
   QudaEigParam qep = newQudaEigParam();
   qep.block_size = blockSize;
   qep.eig_type = ( blockSize > 1 ) ? QUDA_EIG_BLK_TR_LANCZOS : QUDA_EIG_TR_LANCZOS;  /* or QUDA_EIG_IR_ARNOLDI, QUDA_EIG_BLK_IR_ARNOLDI */
   qep.spectrum = QUDA_SPECTRUM_SR_EIG; /* Smallest Real. Other options: LM, SM, LR, SR, LI, SI */
-  qep.n_conv = param.eigen_param.Nvecs_in; // +2?
+  qep.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
   qep.n_ev_deflate = param.eigen_param.Nvecs;
   qep.n_ev = qep.n_conv;
-  qep.n_kr = 2*qep.n_ev;
+  qep.n_kr = (param.eigen_param.Nkr < qep.n_ev ) ? 2*qep.n_ev : param.eigen_param.Nkr;
   qep.tol = param.eigen_param.tol;
-  qep.qr_tol = qep.tol; // change?
+  qep.qr_tol = qep.tol;
   qep.max_restarts = param.eigen_param.MaxIter;
   qep.require_convergence = QUDA_BOOLEAN_TRUE;
-  qep.check_interval = 10; // change?
+  qep.check_interval = 10;
   qep.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   qep.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   qep.use_dagger = QUDA_BOOLEAN_FALSE;
   qep.compute_gamma5 = QUDA_BOOLEAN_FALSE;
   qep.compute_svd = QUDA_BOOLEAN_FALSE;
-  qep.use_eigen_qr = QUDA_BOOLEAN_TRUE; // change?
+  qep.use_eigen_qr = QUDA_BOOLEAN_TRUE;
   qep.use_poly_acc = QUDA_BOOLEAN_TRUE;
   qep.poly_deg = param.eigen_param.poly.norder;
   qep.a_min = param.eigen_param.poly.minE;
@@ -368,25 +363,22 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   strcpy( qep.vec_infile, param.ks_eigen_startfile );
   strcpy( qep.vec_outfile, param.ks_eigen_savefile );
   qep.io_parity_inflate = QUDA_BOOLEAN_FALSE;
-
-  qep.compute_evals_batch_size = 16; // Default is 4
+  qep.compute_evals_batch_size = 16;
   qep.preserve_deflation = QUDA_BOOLEAN_TRUE;
-
-  // If mass changes, eigenvalues need to be recomputed
-  // but no need to recompute on the first solve
-  static Real previous_mass = -1.0;
-  static bool first_solve=true;
   qep.preserve_evals = ( first_solve || fabs(mass - previous_mass) < 1e-6 ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
-  previous_mass = mass;
-  first_solve = false;
-
-  qep.batched_rotate = 20; // add to input parameters
+  qep.batched_rotate = param.eigen_param.batchedRotate;
   qep.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
-  qep.partfile = QUDA_BOOLEAN_TRUE; // add to input parameters
-
+  qep.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
   inv_args.eig_param = qep;
-  inv_args.prec_eigensolver = QUDA_SINGLE_PRECISION;
+  if(param.eigen_param.eigPrec == 2)inv_args.prec_eigensolver = QUDA_DOUBLE_PRECISION;
+  else if(param.eigen_param.eigPrec == 1)inv_args.prec_eigensolver = QUDA_SINGLE_PRECISION;
+  else inv_args.prec_eigensolver = QUDA_HALF_PRECISION;
+
+  inv_args.tol_restart = param.eigen_param.tol_restart;
+
+  previous_mass = mass;
+  first_solve = false;
 
   qudaInvertMsrc(MILC_PRECISION,
      quda_precision,

--- a/generic_ks/mat_invert.c
+++ b/generic_ks/mat_invert.c
@@ -205,7 +205,8 @@ int mat_invert_cg_field(su3_vector *src, su3_vector *dst,
     ks_dirac_adj_op( src, tmp, mass, EVENANDODD, fn);
 
     /* Do deflation if we have eigenvectors and the deflate parameter is true */
-
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
 
       dtime = - dclock();
@@ -222,12 +223,15 @@ int mat_invert_cg_field(su3_vector *src, su3_vector *dst,
       node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
 #endif
     }
+#endif
       
     /* dst_e <- (M_adj M)^-1 tmp_e  (even sites only) */
     qic->parity = EVEN;
     int cgn = ks_congrad_field( tmp, dst, qic, mass, fn );
     int even_iters = qic->final_iters;
 
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
 
       dtime = - dclock();
@@ -242,6 +246,7 @@ int mat_invert_cg_field(su3_vector *src, su3_vector *dst,
       node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
 #endif
     }
+#endif
 
     /* dst_o <- (M_adj M)^-1 tmp_o  (odd sites only) */
     qic->parity = ODD;
@@ -277,6 +282,8 @@ int mat_invert_cgz_field(su3_vector *src, su3_vector *dst,
 
     /* Put "exact" low-mode even-site solution in tmp if deflate parameter is true */
 
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
 
       dtime = - dclock();
@@ -292,6 +299,7 @@ int mat_invert_cgz_field(su3_vector *src, su3_vector *dst,
      node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
 #endif
     }
+#endif
       
     /* Solve for all modes using tmp as an initial guess */
     /* tmp_e <- (M_adj M)^-1 src_e  (even sites only) */
@@ -301,6 +309,8 @@ int mat_invert_cgz_field(su3_vector *src, su3_vector *dst,
 
     /* Put "exact" low-mode odd-site solution in tmp if deflate parameter is true */
 
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
 
       dtime = - dclock();
@@ -316,6 +326,7 @@ int mat_invert_cgz_field(su3_vector *src, su3_vector *dst,
       node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
 #endif
     }
+#endif
 
     /* Solve for all modes using tmp as an initial guess */
     /* tmp_o <- (M_adj M)^-1 src_o  (odd sites only) */
@@ -427,6 +438,8 @@ int mat_invert_uml_field(su3_vector *src, su3_vector *dst,
     ks_dirac_adj_op( src, tmp, mass, EVENANDODD, fn );
 
 #if EIGMODE != EIGCG
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
 
       dtime = - dclock();
@@ -439,6 +452,7 @@ int mat_invert_uml_field(su3_vector *src, su3_vector *dst,
       node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
 #endif
     }
+#endif
 #endif
 
     /* dst_e <- (M_adj M)^-1 tmp_e  (even sites only) */
@@ -460,6 +474,8 @@ int mat_invert_uml_field(su3_vector *src, su3_vector *dst,
     } END_LOOP_OMP;
 
 #if EIGMODE != EIGCG
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
 
       dtime = - dclock();
@@ -470,6 +486,7 @@ int mat_invert_uml_field(su3_vector *src, su3_vector *dst,
       dtime += dclock();
       node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
     }
+#endif
 #endif
 
     /* Polish off odd sites to correct for possible roundoff error */

--- a/generic_ks/mat_invert.c
+++ b/generic_ks/mat_invert.c
@@ -728,7 +728,8 @@ int mat_invert_block_cg(su3_vector **src, su3_vector **dst,
   }
 
   /* Put "exact" low-mode even-site solution in tmp if deflate parameter is true */
-
+  /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
   if(param.eigen_param.Nvecs > 0 && qic->deflate){
 
     dtime = -dclock();
@@ -745,6 +746,7 @@ int mat_invert_block_cg(su3_vector **src, su3_vector **dst,
     node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
 #endif
   }
+#endif
 
   /* dst_e <- (M_adj M)^-1 tmp_e  (even sites only) */
   qic->parity = EVEN;
@@ -752,6 +754,8 @@ int mat_invert_block_cg(su3_vector **src, su3_vector **dst,
   int even_iters = qic->final_iters;
 
   /* Deflation on odd sites */
+  /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
   if(param.eigen_param.Nvecs > 0 && qic->deflate){
     
     dtime = -dclock();
@@ -767,6 +771,7 @@ int mat_invert_block_cg(su3_vector **src, su3_vector **dst,
     node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
 #endif
   }
+#endif
 
   /* dst_o <- (M_adj M)^-1 tmp_o  (odd sites only) */
   qic->parity = ODD;
@@ -797,7 +802,8 @@ int mat_invert_block_cgz(su3_vector **src, su3_vector **dst,
     tmp[is] = create_v_field();
 
   /* Put "exact" low-mode even-site solution in tmp if deflate parameter is true */
-
+  /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
   if(param.eigen_param.Nvecs > 0 && qic->deflate){
     for(int is = 0; is < nsrc; is++){
 
@@ -816,6 +822,7 @@ int mat_invert_block_cgz(su3_vector **src, su3_vector **dst,
 #endif
     }
   }
+#endif
 
   /* Solve for all modes on even sites using tmp as an initial guess */
   /* tmp_e <- (M_adj M)^-1 src_e  (even sites only) */
@@ -824,7 +831,8 @@ int mat_invert_block_cgz(su3_vector **src, su3_vector **dst,
   int even_iters = qic->final_iters;
 
   /* Put "exact" low-mode odd-site solution in tmp if deflate parameter is true */
-
+  /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
   if(param.eigen_param.Nvecs > 0 && qic->deflate){
     for(int is = 0; is < nsrc; is++){
 
@@ -842,6 +850,7 @@ int mat_invert_block_cgz(su3_vector **src, su3_vector **dst,
 #endif
     }
   }
+#endif
 
   /* Solve for all modes on odd sites using tmp as an initial guess */
   /* dst_o <- (M_adj M)^-1 tmp_o  (odd sites only) */
@@ -887,7 +896,9 @@ int mat_invert_block_uml(su3_vector **src, su3_vector **dst,
   
   for(int is = 0; is < nsrc; is++){
     ks_dirac_adj_op( src[is], tmp[is], mass, EVENANDODD, fn );
-    
+
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
       dtime = - dclock();
 #ifdef CGTIME
@@ -901,6 +912,7 @@ int mat_invert_block_uml(su3_vector **src, su3_vector **dst,
       dtime += dclock();
       node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
     }
+#endif
   }
   
   /* dst_e <- (M_adj M)^-1 tmp_e  (even sites only) */
@@ -917,6 +929,8 @@ int mat_invert_block_uml(su3_vector **src, su3_vector **dst,
       scalar_mult_su3_vector( dst[is]+i, 1.0/(2.0*mass), dst[is]+i );
     } END_LOOP_OMP;
 
+    /* Skip MILC CPU deflation if using QUDA deflation */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0 && qic->deflate){
       dtime = - dclock();
       node0_printf("deflating on odd sites for mass %g with %d eigenvec\n",
@@ -927,6 +941,7 @@ int mat_invert_block_uml(su3_vector **src, su3_vector **dst,
       dtime += dclock();
       node0_printf("Time to deflate %d modes %g\n", param.eigen_param.Nvecs, dtime);
     }
+#endif
   }
   
   /* Polish off odd sites to correct for possible roundoff error */

--- a/generic_ks/read_eigen_param.c
+++ b/generic_ks/read_eigen_param.c
@@ -43,6 +43,8 @@ int read_ks_eigen_param(ks_eigen_param *eigen_param, int status, int prompt){
   IF_OK status += get_f(stdin, prompt, "eigenval_tolerance", &eigen_param->tol );
   IF_OK status += get_i(stdin, prompt, "Lanczos_max", &eigen_param->Nkr );
   IF_OK status += get_i(stdin, prompt, "Lanczos_restart", &eigen_param->Nrestart );
+  IF_OK status += get_i(stdin, prompt, "eigensolver_prec", &eigen_param->eigPrec );
+  IF_OK status += get_i(stdin, prompt, "batched_rotate", &eigen_param->batchedRotate );
   IF_OK status += get_f(stdin, prompt, "Chebyshev_alpha", &eigen_param->poly.minE );
   IF_OK status += get_f(stdin, prompt, "Chebyshev_beta", &eigen_param->poly.maxE );
   IF_OK status += get_i(stdin, prompt, "Chebyshev_order", &eigen_param->poly.norder );

--- a/generic_ks/read_eigen_param.c
+++ b/generic_ks/read_eigen_param.c
@@ -31,7 +31,12 @@ int read_ks_eigen_param(ks_eigen_param *eigen_param, int status, int prompt){
   IF_OK status += get_f(stdin, prompt, "Chebyshev_beta", &eigen_param->poly.maxE );
   IF_OK status += get_i(stdin, prompt, "Chebyshev_order", &eigen_param->poly.norder );
   IF_OK status += get_s(stdin, prompt, "diag_algorithm", param.eigen_param.diagAlg );
-  
+
+#elif defined(HAVE_QUDA) && defined(USE_CG_GPU) && !defined(USE_EIG_GPU)
+  node0_printf("ERROR: When using QUDA for CG and wanting FRESH eigenvectors, only the QUDA eigensolver is allowed!\n");
+  node0_printf("ERROR: Recompile with WANT_QUDA=true, WANT_CG_GPU=true, and WANT_EIG_GPU=true\n");
+  terminate(1);
+
 #elif defined(HAVE_QUDA) && defined(USE_EIG_GPU)
   
   IF_OK status += get_i(stdin, prompt, "Max_Lanczos_restart_iters", &eigen_param->MaxIter );    

--- a/include/imp_ferm_links.h
+++ b/include/imp_ferm_links.h
@@ -346,7 +346,8 @@ typedef struct {
   int Nkr; /* size of the Krylov subspace */
   ks_eigen_poly poly; /* Preconditioning polynomial */
   int blockSize; /* block size for block variant eigensolvers */
-  int parity; 
+  int parity;
+  double tol_restart; 
 } ks_eigen_param;
 #elif defined(HAVE_QDP)
 #define ks_eigensolve Kalkreuter
@@ -371,6 +372,7 @@ typedef struct {
   int Restart ; /* Restart  Rayleigh every so many iterations */
   int Kiters ; /* Kalkreuter iterations */
   int parity; 
+  double tol_restart;
 } ks_eigen_param;
 #endif
 

--- a/include/imp_ferm_links.h
+++ b/include/imp_ferm_links.h
@@ -346,6 +346,9 @@ typedef struct {
   int Nkr; /* size of the Krylov subspace */
   ks_eigen_poly poly; /* Preconditioning polynomial */
   int blockSize; /* block size for block variant eigensolvers */
+  int partfile; /* Whether to save in partfile or not */
+  int eigPrec; /* Run the eigensolver in this precision */
+  int batchedRotate; /* Size of the rotation space to use for solver */
   int parity;
   double tol_restart; 
 } ks_eigen_param;

--- a/ks_spectrum/control.c
+++ b/ks_spectrum/control.c
@@ -318,6 +318,8 @@ int main(int argc, char *argv[])
 #endif
     
 #if EIGMODE != EIGCG
+    /* If using QUDA for deflation, then eigenvectors are loaded directly by QUDA and not MILC */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
     if(param.eigen_param.Nvecs > 0){
       /* malloc for eigenpairs */
       eigVal = (Real *)malloc(param.eigen_param.Nvecs*sizeof(double));
@@ -338,6 +340,7 @@ int main(int argc, char *argv[])
 	node0_printf("WARNING: Gauge fixing does not readjust the eigenvectors");
       }
     }
+#endif
 #endif
     
     /**************************************************************/
@@ -378,6 +381,8 @@ int main(int argc, char *argv[])
     
       /* Check the eigenvectors */
 
+      /* If using QUDA for deflation, then eigenvectors are loaded directly by QUDA and not checked by MILC */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
       /* Calculate and print the residues and norms of the eigenvectors */
       resid = (Real *)malloc(Nvecs_curr*sizeof(double));
       node0_printf("Even site residuals\n");
@@ -385,12 +390,14 @@ int main(int argc, char *argv[])
       construct_eigen_other_parity(eigVec, eigVal, &param.eigen_param, fn);
       node0_printf("Odd site residuals\n");
       check_eigres( resid, eigVec, eigVal, Nvecs_curr, ODD, fn );
-      
+#endif
       /* Unapply twisted boundary conditions on the fermion links and
 	 restore conventional KS phases and antiperiodic BC, if
 	 changed. */
       boundary_twist_fn(fn, OFF);
-      
+     
+      /* If using QUDA for deflation, then eigenvalues are printed by QUDA */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) ) 
       /* print eigenvalues of iDslash */
       node0_printf("The above were eigenvalues of -Dslash^2 in MILC normalization\n");
       node0_printf("Here we also list eigenvalues of iDslash in continuum normalization\n");
@@ -403,6 +410,7 @@ int main(int argc, char *argv[])
 	  node0_printf("eigenval(%i): %10g\n", i, 0.0);
 	}
       }
+#endif
 #endif
     }
     

--- a/ks_spectrum/control.c
+++ b/ks_spectrum/control.c
@@ -362,7 +362,10 @@ int main(int argc, char *argv[])
       set_boundary_twist_fn(fn, bdry_phase, param.coord_origin);
       /* Apply the operation */
       boundary_twist_fn(fn, ON);
-      
+
+      // If using QUDA deflated CG + asking for QUDA to do the eigensolve, then
+      // the eigensolver is called from within QUDA's CG solver...not from MILC
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) && defined(USE_EIG_GPU) ) 
       /* compute eigenpairs if requested */
       if(param.ks_eigen_startflag == FRESH){
 	int total_R_iters;
@@ -378,7 +381,7 @@ int main(int argc, char *argv[])
 	initialize_site_prn_from_seed(iseed);
 #endif
       }
-    
+#endif
       /* Check the eigenvectors */
 
       /* If using QUDA for deflation, then eigenvectors are loaded directly by QUDA and not checked by MILC */
@@ -955,6 +958,9 @@ int main(int argc, char *argv[])
 #endif
 
     if(param.eigen_param.Nvecs > 0){
+
+      /* If using QUDA for deflation, then eigenvectors are loaded and saved directly by QUDA and not MILC */
+#if !( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
       STARTTIME;
       
       /* save eigenvectors if requested */
@@ -969,6 +975,8 @@ int main(int argc, char *argv[])
       free(eigVal); free(eigVec); free(resid);
 
       ENDTIME("save eigenvectors (if requested)");
+
+#endif
     }
 
     /* Clean up quark sources, both base and modified */

--- a/ks_spectrum/setup.c
+++ b/ks_spectrum/setup.c
@@ -693,7 +693,6 @@ int readin(int prompt) {
 	}
 
 	IF_OK param.ksp[nprop].mass = atof(param.mass_label[nprop]);
-
 	IF_OK {
 	  int dir;
 	  FORALLUPDIR(dir)param.bdry_phase[nprop][dir] = bdry_phase[dir];
@@ -725,9 +724,10 @@ int readin(int prompt) {
 	param.qic[nprop].deflate = 0;
 	IF_OK {
 	  if(param.eigen_param.Nvecs > 0){  /* Need eigenvectors to deflate */
-	    IF_OK status += get_s(stdin, prompt,"deflate", savebuf);
+	    char savebuf2[128];
+	    IF_OK status += get_s(stdin, prompt,"deflate", savebuf2);
 	    IF_OK {
-	      if(strcmp(savebuf,"yes") == 0)param.qic[nprop].deflate = 1;
+	      if(strcmp(savebuf2,"yes") == 0)param.qic[nprop].deflate = 1;
 	    }
 	  }
 	}

--- a/ks_spectrum/setup.c
+++ b/ks_spectrum/setup.c
@@ -256,6 +256,14 @@ int readin(int prompt) {
 
     IF_OK if(param.eigen_param.Nvecs > 0){
 
+      /* Additional parameters for QUDA deflation */
+#if ( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
+      /* allow file to have more eigenpairs than will be used for deflation */
+      IF_OK status += get_i(stdin, prompt,"file_number_of_eigenpairs", &param.eigen_param.Nvecs_in);
+      /* controls how often redeflation occurs during deflated inversions */
+      IF_OK status += get_f(stdin, prompt,"tol_restart", &param.eigen_param.tol_restart);
+#endif
+
       /* eigenvector input */
       IF_OK status += ask_starting_ks_eigen(stdin, prompt, &param.ks_eigen_startflag,
 					    param.ks_eigen_startfile);

--- a/ks_spectrum/setup.c
+++ b/ks_spectrum/setup.c
@@ -258,8 +258,6 @@ int readin(int prompt) {
 
       /* Additional parameters for QUDA deflation */
 #if ( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
-      /* allow file to have more eigenpairs than will be used for deflation */
-      IF_OK status += get_i(stdin, prompt,"file_number_of_eigenpairs", &param.eigen_param.Nvecs_in);
       /* controls how often redeflation occurs during deflated inversions */
       IF_OK status += get_f(stdin, prompt,"tol_restart", &param.eigen_param.tol_restart);
 #endif
@@ -268,9 +266,27 @@ int readin(int prompt) {
       IF_OK status += ask_starting_ks_eigen(stdin, prompt, &param.ks_eigen_startflag,
 					    param.ks_eigen_startfile);
 
+      /* Additional parameters for QUDA deflation */
+#if ( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
+      if(param.ks_eigen_startflag == RELOAD_ASCII || 
+		      param.ks_eigen_startflag == RELOAD_SERIAL ||
+		      param.ks_eigen_startflag == RELOAD_PARALLEL ){
+      /* allow file to have more eigenpairs than will be used for deflation */
+        IF_OK status += get_i(stdin, prompt,"file_number_of_eigenpairs", &param.eigen_param.Nvecs_in);
+      }
+#endif
+
       /* eigenvector output */
       IF_OK status += ask_ending_ks_eigen(stdin, prompt, &param.ks_eigen_saveflag,
 					  param.ks_eigen_savefile);
+
+#if ( defined(USE_CG_GPU) && defined(HAVE_QUDA) )
+      if(param.ks_eigen_saveflag == SAVE_PARTFILE_SCIDAC){
+        param.eigen_param.partfile = 1;
+      } else {
+	param.eigen_param.partfile = 0;
+      }
+#endif
 
       /* If we are reading in eigenpairs, we don't regenerate them */
 


### PR DESCRIPTION
This pull request implements QUDA deflation for `ks_spectrum` with support for multiple right-hand sides. Previously, MILC deflation was done on CPU.

Key points:

1. 	To use all of the features, `ks_spectrum` must be compiled with `WANT_QUDA`, `WANT_FN_CG_GPU`, and `WANT_EIG_GPU` all true
2. 	QUDA deflation is implemented for UML, CG, and CGZ, for single and multiple right-hand sides but will only apply to the even parity solves
3. 	Eigenvector files are loaded and saved directly by QUDA--MILC's corresponding functions are bypassed
4. 	Using `fresh_ks_eigen` with `ks_spectrum` will trigger QUDA's eigensolve internally. MILC's eigensolve functions are bypassed
5. 	This functionality depends on changes made from the QUDA side as well. Until those are merged into QUDA develop, you can use the `leonhostetler/milc_batched_deflation` branch of `https://github.com/leonhostetler/quda.git`

More details:

Using `ks_spectrum` with `fresh_ks_eigen` is now working. So there is no longer a need to do a two-part process where the eigenvectors are generated using QUDA's standalone eigensolver and then using MILC's ks_spectrum to load the eigenvectors and do the deflation. The `ks_spectrum` application can now handle both the eigensolve and CG solves in the same run.

This is implemented for UML, CG, and CGZ, however, deflation only occurs for the even parity solves. For UML, where the odd parity solve is just a polishing of the odd solution reconstructed from the even solution, this works well since the odd solve typically requires many fewer iterations. However, for CG and CGZ, this means that only the even half of the problem will be sped up by deflation. If there is a need for odd parity deflation, we'll need to think about how best to implement that in the future.

Note that eigenvector files are loaded and saved from within QUDA--not MILC. This was both the simplest way to interface with the QUDA solver and the way that ensured minimal memory usage. For example, if MILC loaded the eigenvectors and then passed them to QUDA, then the host memory usage would be doubled, and this is not a feasible approach given the size of eigenvectors. This way, MILC only passes the filenames back and forth to QUDA. If e.g. one wants to use non-QUDA eigenvectors with the QUDA deflated solver, then one would need a separate utility to convert the file to QUDA-readable format, save it to disk, and then run `ks_spectrum` with the QUDA solver.

The QUDA deflation should work fine for varying masses. If different quark masses are used for different propagators, the eigenvectors remain the same, but the eigenvalues need to be updated since they depend on the quark mass by $+4m^2$. This is taken care of automatically. The eigenvalues are preserved unless the quark mass changes, and then they are automatically recalculated.

In a real-world application to compute many correlators, the job is typically chunked into readin sets. The gauge field is loaded for the first readin set and then "continue" is used for subsequent readin sets. With QUDA's ability to preserve the deflation space, the eigenvectors are handled in a similar manner. For the first readin set, the eigenvectors are either read in or generated. For subsequent readin sets, one must still include the parameters for reloading or generating the eigenvectors, however, these are ignored because QUDA will just continue with the initial set of eigenvectors. Thus, for multiple readin sets one does not have to worry that unnecessary time is spent reloading the eigenvectors and recomputing the eigenvalues. This also means that one cannot change eigenvector sets during a run. This behavior could be modified by changing `qep.preserve_deflation_space` if desired, but I don't think it's necessary. If one wants to switch to different eigenvectors, one might as well do a separate run.

One can adjust the eigensolver precision from the input parameter file. Typically, single precision should be fine. However, with such "sloppy" eigenvectors, it is important that the deflation is repeated periodically during the CG solve. This is controlled by the `tol_restart` parameter.

When eigenvectors are saved to disk, they are saved in single precision. This could be modified easily, but there should be no need to save them in double precision since single precision eigenvectors are fine provided that `tol_restart` is reasonable.

Note that QUDA's block TRLM does not seem to be working well yet, so leave block_size at 1.

In general, when using QUDA deflation, the ks_spectrum application will need an input file with parameters like:
```
max_number_of_eigenpairs 512 		# How many eigenvectors to use for deflation
tol_restart 1e-2 			# How often to do the redeflation
```
When loading eigenvectors from file, use a parameter block like:
```
reload_parallel_ks_eigen [filename]	# This works with both single file and partfile formats
file_number_of_eigenpairs 512		# In case the file has more eigenvectors than will be used to deflate
forget_ks_eigen 			# Don't save the eigenvectors to file
```
Alternatively, when generating fresh eigenvectors, use a parameter block like:
```
fresh_ks_eigen				# Run QUDA's eigensolver
save_partfile_ks_eigen [filename] 	# Use save_parallel_ks_eigen for single file format or forget_ks_eigen to discard
Max_Lanczos_restart_iters 1000		# Max number of Lanczos restart iterations
eigenval_tolerance 1e-12		# Eigenvalue tolerance
Lanczos_max 1024			# Size of Krylov space, corresponds to QUDA's n_kr
Lanczos_restart 1000			# Deprecated, does nothing as far as I can tell
eigensolver_prec 1			# Precision in eigensolver, double=2, single=1, half=0
batched_rotate 20			# Size of batch_rotate
Chebyshev_alpha 0.1			# Must be larger than 4*m^2 for largest quark mass that will be deflated
Chebyshev_beta 0			# Leave at 0 for QUDA to estimate internally
Chebyshev_order 100			# Chebyshev order
block_size 1				# block_size>1 implies block TRLM (doesn't work well yet?)
```
Also, don't forget to set
```
deflate yes/no
```
in the propagator stanzas.