### PR TITLE
Minor deflation bugfix

### DIFF
--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -140,7 +140,7 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
   eig_args.block_size = blockSize;
   eig_args.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
-  eig_args.n_ev_deflate = ( parity == EVEN ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
+  eig_args.n_ev_deflate = ( parity == EVEN && qic->deflate ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
   eig_args.n_ev = eig_args.n_conv;
   eig_args.n_kr = (param.eigen_param.Nkr < eig_args.n_ev ) ? 2*eig_args.n_ev : param.eigen_param.Nkr;
   eig_args.tol = param.eigen_param.tol;
@@ -352,7 +352,7 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
   eig_args.block_size = blockSize;
   eig_args.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
-  eig_args.n_ev_deflate = ( parity == EVEN ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
+  eig_args.n_ev_deflate = ( parity == EVEN && qic->deflate ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
   eig_args.n_ev = eig_args.n_conv;
   eig_args.n_kr = (param.eigen_param.Nkr < eig_args.n_ev ) ? 2*eig_args.n_ev : param.eigen_param.Nkr;
   eig_args.tol = param.eigen_param.tol;


### PR DESCRIPTION
Deflation was attempted whenever max_number_of_eigenpairs>0 regardless of the value of the deflate parameter set in the propagator stanzas in the input file.

This fix disables deflation if "deflate no" is set in the propagator stanza