### PR TITLE
Multiple right hand side QUDA HISQ MG support

### DIFF
--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -140,7 +140,7 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
   eig_args.block_size = blockSize;
   eig_args.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
-  eig_args.n_ev_deflate = ( parity == EVEN ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
+  eig_args.n_ev_deflate = ( parity == EVEN && qic->deflate ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
   eig_args.n_ev = eig_args.n_conv;
   eig_args.n_kr = (param.eigen_param.Nkr < eig_args.n_ev ) ? 2*eig_args.n_ev : param.eigen_param.Nkr;
   eig_args.tol = param.eigen_param.tol;
@@ -352,7 +352,7 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
   eig_args.block_size = blockSize;
   eig_args.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
-  eig_args.n_ev_deflate = ( parity == EVEN ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
+  eig_args.n_ev_deflate = ( parity == EVEN && qic->deflate ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
   eig_args.n_ev = eig_args.n_conv;
   eig_args.n_kr = (param.eigen_param.Nkr < eig_args.n_ev ) ? 2*eig_args.n_ev : param.eigen_param.Nkr;
   eig_args.tol = param.eigen_param.tol;

--- a/generic_ks/mat_invert.c
+++ b/generic_ks/mat_invert.c
@@ -637,8 +637,7 @@ int mat_invert_mg_field_gpu(su3_vector *t_src, su3_vector *t_dest,
   if (qic->mg_rebuild_type == THINREBUILD) {
     mg_rebuild_type = 0;
   } 
-  
-  // Just BiCGstab for now
+
   qudaInvertMG(MILC_PRECISION,
 	       quda_precision, 
 	       mass,
@@ -967,13 +966,188 @@ int mat_invert_block_mg(su3_vector **src, su3_vector **dst,
 			Real mass, int nsrc, quark_invert_control *qic,
 			imp_ferm_links_t *fn){
   
-  int cgn = 0;
+  //int cgn = 0;
   
   /* Temporary until there is multi-rhs support for multigrid */
-  for(int is = 0; is < nsrc; is++) {
-    cgn += mat_invert_mg_field_gpu(src[is], dst[is], qic, mass, fn );
+  //for(int is = 0; is < nsrc; is++) {
+  //  cgn += mat_invert_mg_field_gpu(src[is], dst[is], qic, mass, fn );
+  //}
+  //return cgn;
+
+#ifdef MULTIGRID
+  char myname[] = "mat_invert_block_mg";
+  QudaInvertArgs_t inv_args;
+  int i;
+  double dtimec = -dclock();
+#ifdef CGTIME
+  double nflop = 1187;
+#endif
+
+  /* Initialize qic */
+  qic->size_r = 0;
+  qic->size_relr = 0;
+  qic->final_iters   = 0;
+  qic->final_restart = 0;
+  qic->converged     = 1;
+  qic->final_rsq = 0.;
+  qic->final_relrsq = 0.;
+
+  
+  /* Initialize QUDA parameters */
+  initialize_quda();
+
+  // need to set a dummy value, ignored (for now),
+  // MG will eventually support Schur solve
+  inv_args.evenodd = QUDA_EVEN_PARITY; 
+  /*if(qic->parity == EVEN){
+          inv_args.evenodd = QUDA_EVEN_PARITY;
+  }else if(qic->parity == ODD){
+          inv_args.evenodd = QUDA_ODD_PARITY;
+  }else{
+    printf("%s: Unrecognised parity\n",myname);
+    terminate(2);
+  }*/
+
+  inv_args.max_iter = qic->max * qic->nrestart;
+#if defined(MAX_MIXED)
+  inv_args.mixed_precision = 2;
+#elif defined(HALF_MIXED)
+  inv_args.mixed_precision = 1;
+#else
+  inv_args.mixed_precision = 0;
+#endif
+
+  su3_matrix* fatlink = get_fatlinks(fn);
+  su3_matrix* longlink = get_lnglinks(fn);
+  const int quda_precision = qic->prec;
+  
+  double residual, relative_residual;
+  int num_iters = 0;
+  
+  inv_args.naik_epsilon = fn->eps_naik;
+
+#if (FERM_ACTION==HISQ)
+  inv_args.tadpole = 1.0;
+#else
+  inv_args.tadpole = u0;
+#endif
+
+  // for newer versions of QUDA we need to invalidate the gauge field if the links are new
+  if ( fn != get_fn_last() || fresh_fn_links(fn) ){
+
+    node0_printf("%s: fn, notify: Signal QUDA to refresh links\n", myname);
+    cancel_quda_notification(fn);
+    set_fn_last(fn);
+    /* Hack to cause QUDA to copy new links to the GPU */
+    num_iters = -1;
+
+    node0_printf("%s: setting up the MG inverter\n", myname);
+
+    /* Set up the MG inverter when the links change */
+    /* FIXME: what do we do if the mgparamfile changes? */
+
+    if (mg_preconditioner == NULL ){
+      double mg_regen_time = -dclock();
+      mg_preconditioner = qudaMultigridCreate(MILC_PRECISION,
+                              quda_precision,
+                              mass,
+                              inv_args,
+                              fatlink,
+                              longlink,
+                              qic->mgparamfile);
+
+      mg_regen_time += dclock();
+      node0_printf("%s: MG inverter setup complete. Time = %g\n", myname, mg_regen_time);
+    } else {
+      node0_printf("%s: MG inverter already set up.  Skipping.\n", myname);
+    }
   }
-  return cgn;
+
+  /* Specify the type of rebuild _if_ a rebuild is required */
+  int mg_rebuild_type = 1;
+  if (qic->mg_rebuild_type == THINREBUILD) {
+    mg_rebuild_type = 0;
+  }
+
+  int cgn = 0;
+
+  /* check norms */
+  for (int is = 0; is < nsrc; is++) {
+
+    node0_printf("%s: starting source %d\n", myname, is);
+
+    /* Compute source norm */
+    double source_norm = 0.0;
+    FORSOMEFIELDPARITY(i,qic->parity){
+      source_norm += (double)magsq_su3vec( &src[is][i] );
+    } END_LOOP;
+    g_doublesum( &source_norm );
+#ifdef CG_DEBUG
+    node0_printf("%s: source %d source_norm = %e\n", myname, is, (double)source_norm);
+#endif
+
+    /* Provide for trivial solution */
+    if (source_norm == 0.0) {
+      /* Zero the solution and do not update the number of iterations */
+      FORSOMEFIELDPARITY(i, qic->parity){
+        memset(dst[is] + i, 0, sizeof(su3_vector));
+      } END_LOOP;
+    }
+  }
+
+  qudaInvertMsrcMG(MILC_PRECISION,
+        quda_precision, 
+        mass,
+        inv_args,
+        qic->resid,
+        qic->relresid,
+        fatlink, 
+        longlink,
+        mg_preconditioner,
+        mg_rebuild_type,
+        (void**)src,
+        (void**)dst,
+        &residual,
+        &relative_residual, 
+        &num_iters,
+        nsrc);
+
+  qic->final_rsq = residual*residual;
+  qic->final_relrsq = relative_residual*relative_residual;
+  qic->final_iters = num_iters;
+
+  // check for convergence 
+  qic->converged = (residual < qic->resid) ? 1 : 0;
+
+  // Cumulative residual. Not used in practice 
+  qic->size_r = 0.0;
+  qic->size_relr = 0.0;
+
+  dtimec += dclock();
+
+#ifdef CGTIME
+  if(this_node==0){
+    printf("CONGRAD5: time = %e (fn_QUDA %s) masses = 1 srcs = %d iters = %d mflops = %e\n",
+           dtimec, prec_label[quda_precision-1], nsrc, qic->final_iters,
+           (double)(nflop*nsrc*volume*qic->final_iters/(1.0e6*dtimec*numnodes())) );
+    fflush(stdout);
+  }
+#endif
+
+    //node0_printf("Entering check_invert_field in mat_invert_mg_field_gpu\n");
+    //  fflush(stdout);
+    //  check_invert_field( t_dest, t_src, mass, 1e-6, fn, EVENANDODD);
+
+  report_status(qic);
+
+  return num_iters;
+
+#else
+  node0_printf("%s: ERROR. Multigrid is available only with GPU compilation\n", myname);
+  terminate(1);
+  return 0;  
+#endif
+
 }
 #endif
 

--- a/ks_spectrum/params.h
+++ b/ks_spectrum/params.h
@@ -110,6 +110,7 @@ typedef struct {
   int num_set;  /* number of sets */
   enum set_type set_type[MAX_SET];    /* multimass or multisource */
   enum inv_type inv_type[MAX_SET];    /* inverter type MG or CG */
+  enum mg_rebuild_type mg_rebuild_type[MAX_SET];    /* how to refresh MG solve if mass/gauge links change for multisource set */
   Real charge[MAX_SET];     /* charge for propagators in the set */
   char charge_label[MAX_SET][32];  /* for correlator label */
   int num_prop[MAX_SET]; /* number of propagators in a set */

--- a/ks_spectrum/setup.c
+++ b/ks_spectrum/setup.c
@@ -535,42 +535,68 @@ int readin(int prompt) {
 
       IF_OK status += get_s(stdin, prompt, "set_type", savebuf);
       IF_OK {
-	if(strcmp(savebuf,"multimass") == 0)
-	  param.set_type[k] = MULTIMASS_SET;
-	else if(strcmp(savebuf,"multisource") == 0)
-	  param.set_type[k] = MULTISOURCE_SET;
-	else if(strcmp(savebuf,"single") == 0)
-	  param.set_type[k] = SINGLES_SET;
-	else if(strcmp(savebuf,"multicolorsource") == 0)
-	  param.set_type[k] = MULTICOLORSOURCE_SET;
-	else {
-	  printf("Unrecognized set type %s\n",savebuf);
-	  printf("Choices are 'single', 'multimass', 'multisource', 'multicolorsource'\n");
-	  status++;
-	}
+        if(strcmp(savebuf,"multimass") == 0)
+          param.set_type[k] = MULTIMASS_SET;
+        else if(strcmp(savebuf,"multisource") == 0)
+          param.set_type[k] = MULTISOURCE_SET;
+        else if(strcmp(savebuf,"single") == 0)
+          param.set_type[k] = SINGLES_SET;
+        else if(strcmp(savebuf,"multicolorsource") == 0)
+          param.set_type[k] = MULTICOLORSOURCE_SET;
+        else {
+          printf("Unrecognized set type %s\n",savebuf);
+          printf("Choices are 'single', 'multimass', 'multisource', 'multicolorsource'\n");
+          status++;
+        }
       }
 
       IF_OK status += get_s(stdin, prompt, "inv_type", savebuf);
       IF_OK {
-	if(strcmp(savebuf,"MG") == 0)
-	  param.inv_type[k] = MGTYPE;
-	else if(strcmp(savebuf,"CG") == 0)
-	  param.inv_type[k] = CGTYPE;
-	else if(strcmp(savebuf,"CGZ") == 0)
-	  param.inv_type[k] = CGZTYPE;
-	else if(strcmp(savebuf,"UML") == 0)
-	  param.inv_type[k] = UMLTYPE;
-	else {
-	  printf("Unrecognized inverter type %s\n",savebuf);
-	  printf("Choices are 'CG', 'CGZ', 'MG', 'UML'\n");
-	  status++;
-	}
+        if(strcmp(savebuf,"MG") == 0)
+          param.inv_type[k] = MGTYPE;
+        else if(strcmp(savebuf,"CG") == 0)
+          param.inv_type[k] = CGTYPE;
+        else if(strcmp(savebuf,"CGZ") == 0)
+          param.inv_type[k] = CGZTYPE;
+        else if(strcmp(savebuf,"UML") == 0)
+          param.inv_type[k] = UMLTYPE;
+        else {
+          printf("Unrecognized inverter type %s\n",savebuf);
+          printf("Choices are 'CG', 'CGZ', 'MG', 'UML'\n");
+          status++;
+        }
       }
       
       IF_OK {
         if (param.inv_type[k] == MGTYPE) {
           IF_OK status += get_s(stdin, prompt, "MGparams", mgparamfile);
         }
+
+#ifdef MULTIGRID
+        /* parameter within MG solve to specify how to refresh the coarse op */
+
+        IF_OK {
+          if (param.inv_type[k] == MGTYPE &&
+              (param.set_type[k] == MULTISOURCE_SET || param.set_type[k] == MULTICOLORSOURCE_SET)) {
+            IF_OK status += get_s(stdin, prompt, "rebuild_type", savebuf);
+            IF_OK {
+              if(strcmp(savebuf,"FULL") == 0)
+                param.mg_rebuild_type[k] = FULLREBUILD;
+              else if(strcmp(savebuf,"THIN") == 0)
+                param.mg_rebuild_type[k] = THINREBUILD;
+              else if(strcmp(savebuf,"CG") == 0)
+                param.mg_rebuild_type[k] = CGREBUILD;
+              else {
+                printf("Unrecognized rebuild type %s\n",savebuf);
+                printf("Choices are 'FULL', 'THIN', 'CG'\n");
+                status++;
+              }
+            }
+          }
+        }
+#else
+        param.mg_rebuild_type[k] = CGREBUILD;
+#endif
 
 	/* maximum no. of conjugate gradient iterations */
         IF_OK status += get_i(stdin,prompt,"max_cg_iterations", 
@@ -667,8 +693,8 @@ int readin(int prompt) {
       }
 
       if( param.inv_type[k] == MGTYPE && param.set_type[k] == MULTIMASS_SET
-	  && param.num_prop[k] > 1){
-	node0_printf("WARNING: Multigrid support for multimass is currently emulated via separate inversions\n");
+        && param.num_prop[k] > 1){
+        node0_printf("WARNING: Multigrid support for multimass is currently emulated via separate inversions\n");
       }
 
       /* Indexing range for set */
@@ -733,7 +759,7 @@ int readin(int prompt) {
 	/*------------------------------------------------------------*/
 	/* Propagator inversion control                               */
 	/*------------------------------------------------------------*/
-	
+
         /* inversion type */
         param.qic[nprop].inv_type = param.inv_type[k];
 
@@ -768,31 +794,30 @@ int readin(int prompt) {
 	IF_OK status += get_f(stdin, prompt,"rel_error_for_propagator",
 			      &param.qic[nprop].relresid );
 #if defined(HALF_MIXED) && defined(HAVE_QOP)
-	/* Parameter used by QOPQDP inverter for mixed-precision solves ?? */
-	IF_OK status += get_f(stdin, prompt, "mixed_rsq", &param.qic[nprop].mixed_rsq );
+  /* Parameter used by QOPQDP inverter for mixed-precision solves ?? */
+  IF_OK status += get_f(stdin, prompt, "mixed_rsq", &param.qic[nprop].mixed_rsq );
 #endif
 
 #ifdef MULTIGRID
   /* parameter within MG solve to specify how to refresh the coarse op */
-
-	IF_OK {
-	  if (param.inv_type[k] == MGTYPE) {
-	    IF_OK status += get_s(stdin, prompt, "rebuild_type", savebuf);
-	    IF_OK {
-	      if(strcmp(savebuf,"FULL") == 0)
-		param.qic[nprop].mg_rebuild_type = FULLREBUILD;
-	      else if(strcmp(savebuf,"THIN") == 0)
-		param.qic[nprop].mg_rebuild_type = THINREBUILD;
-	      else if(strcmp(savebuf,"CG") == 0)
-		param.qic[nprop].mg_rebuild_type = CGREBUILD;
-	      else {
-		printf("Unrecognized rebuild type %s\n",savebuf);
-		printf("Choices are 'FULL', 'THIN', 'CG'\n");
-		status++;
-	      }
-	    }
-	  }
-	}
+  IF_OK {
+    if (param.inv_type[k] == MGTYPE && param.set_type[k] == MULTIMASS_SET) {
+      IF_OK status += get_s(stdin, prompt, "rebuild_type", savebuf);
+      IF_OK {
+        if(strcmp(savebuf,"FULL") == 0)
+          param.qic[nprop].mg_rebuild_type = FULLREBUILD;
+        else if(strcmp(savebuf,"THIN") == 0)
+          param.qic[nprop].mg_rebuild_type = THINREBUILD;
+        else if(strcmp(savebuf,"CG") == 0)
+          param.qic[nprop].mg_rebuild_type = CGREBUILD;
+        else {
+          printf("Unrecognized rebuild type %s\n",savebuf);
+          printf("Choices are 'FULL', 'THIN', 'CG'\n");
+          status++;
+        }
+      }
+    }
+  }
 #else
   param.qic[nprop].mg_rebuild_type = CGREBUILD;
 #endif


### PR DESCRIPTION
This PR exposes support for the multi-rhs batch HISQ MG solver in QUDA; the MILC interface for this was recently merged into QUDA develop in https://github.com/lattice/quda/pull/1565 .

This also exposes two new fields in the `mgparams.txt` file:

- `deflate_block_size`: Exposes the option to use block TRLM for coarsest-level deflation; the default is 1 which is sticking with regular TRLM
- `block_solver_batch_Size`: Exposes the option to set a batch size for multi-rhs MG solves; The default is to solve all rhs in one go, but by setting some integer value solves will be performed in batches of that size regardless of the number of rhs MILC passes in

@leonhostetler confirmed that he tested this branch here: https://github.com/lattice/quda/pull/1565#pullrequestreview-2822191599

So hopefully this is a smooth merge. I have the outstanding action item of updating the QUDA wiki page on MILC-driven HISQ MG.