### PR TITLE
Quda two-parity deflation

### DIFF
--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -140,7 +140,7 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
   eig_args.block_size = blockSize;
   eig_args.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
-  eig_args.n_ev_deflate = ( parity == EVEN && qic->deflate ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
+  eig_args.n_ev_deflate = ( qic->deflate ) ? param.eigen_param.Nvecs : 0;
   eig_args.n_ev = eig_args.n_conv;
   eig_args.n_kr = (param.eigen_param.Nkr < eig_args.n_ev ) ? 2*eig_args.n_ev : param.eigen_param.Nkr;
   eig_args.tol = param.eigen_param.tol;
@@ -150,12 +150,12 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   eig_args.a_max = param.eigen_param.poly.maxE;
   strcpy( eig_args.vec_infile, param.ks_eigen_startfile );
   strcpy( eig_args.vec_outfile, param.ks_eigen_savefile );
-  eig_args.vec_in_parity = QUDA_EVEN_PARITY; // TODO: Update when we add support for odd parity eigenvector files
+//  eig_args.vec_in_parity = QUDA_EVEN_PARITY; // TODO: Update when we add support for odd parity eigenvector files
   eig_args.preserve_evals = ( first_solve || fabs(mass - previous_mass) < 1e-6 ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.batched_rotate = param.eigen_param.batchedRotate;
   eig_args.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
   eig_args.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
-  eig_args.io_parity_inflate = QUDA_BOOLEAN_FALSE;
+  eig_args.io_parity_inflate = QUDA_BOOLEAN_TRUE;
   eig_args.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.tol_restart = param.eigen_param.tol_restart;
@@ -352,7 +352,7 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
   eig_args.block_size = blockSize;
   eig_args.n_conv = (param.eigen_param.Nvecs_in > param.eigen_param.Nvecs) ? param.eigen_param.Nvecs_in : param.eigen_param.Nvecs;
-  eig_args.n_ev_deflate = ( parity == EVEN && qic->deflate ) ? param.eigen_param.Nvecs : 0; // Only deflate even solves for now
+  eig_args.n_ev_deflate = ( qic->deflate ) ? param.eigen_param.Nvecs : 0;
   eig_args.n_ev = eig_args.n_conv;
   eig_args.n_kr = (param.eigen_param.Nkr < eig_args.n_ev ) ? 2*eig_args.n_ev : param.eigen_param.Nkr;
   eig_args.tol = param.eigen_param.tol;
@@ -362,12 +362,12 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   eig_args.a_max = param.eigen_param.poly.maxE;
   strcpy( eig_args.vec_infile, param.ks_eigen_startfile );
   strcpy( eig_args.vec_outfile, param.ks_eigen_savefile );
-  eig_args.vec_in_parity = QUDA_EVEN_PARITY; // TODO: Update when we add support for odd parity eigenvector files
+//  eig_args.vec_in_parity = QUDA_EVEN_PARITY; // TODO: Update when we add support for odd parity eigenvector files
   eig_args.preserve_evals = ( first_solve || fabs(mass - previous_mass) < 1e-6 ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.batched_rotate = param.eigen_param.batchedRotate;
   eig_args.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
   eig_args.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
-  eig_args.io_parity_inflate = QUDA_BOOLEAN_FALSE;
+  eig_args.io_parity_inflate = QUDA_BOOLEAN_TRUE;
   eig_args.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.tol_restart = param.eigen_param.tol_restart;

--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -133,8 +133,6 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   // Setup for deflation (and eigensolve) on GPU
   int parity = qic->parity;
   int blockSize = param.eigen_param.blockSize;
-  static Real previous_mass = -1.0;
-  static bool first_solve=true;
 
   QudaEigensolverArgs_t eig_args;
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
@@ -151,7 +149,7 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   strcpy( eig_args.vec_infile, param.ks_eigen_startfile );
   strcpy( eig_args.vec_outfile, param.ks_eigen_savefile );
 //  eig_args.vec_in_parity = QUDA_EVEN_PARITY; // TODO: Update when we add support for odd parity eigenvector files
-  eig_args.preserve_evals = ( first_solve || fabs(mass - previous_mass) < 1e-6 ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  eig_args.preserve_evals = QUDA_BOOLEAN_TRUE; // Default to preserving the eigenvalues
   eig_args.batched_rotate = param.eigen_param.batchedRotate;
   eig_args.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
   eig_args.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
@@ -183,9 +181,6 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
     printf("%s: Unrecognized eigensolver precision\n",myname);
     terminate(2);
   }
-
-  previous_mass = mass;
-  first_solve = false;
 
   qudaInvertDeflatable(MILC_PRECISION,
 	     quda_precision, 
@@ -345,8 +340,6 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   // Setup for deflation (and eigensolve) on GPU
   int parity = qic->parity;
   int blockSize = param.eigen_param.blockSize;
-  static Real previous_mass = -1.0;
-  static bool first_solve=true;
 
   QudaEigensolverArgs_t eig_args;
   eig_args.struct_size = 1192; // Could also use sizeof(QudaEigensolverArgs_t) to automagically update, but using a static number will catch the case when the struct is updated by QUDA but MILC is not updated
@@ -363,7 +356,7 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   strcpy( eig_args.vec_infile, param.ks_eigen_startfile );
   strcpy( eig_args.vec_outfile, param.ks_eigen_savefile );
 //  eig_args.vec_in_parity = QUDA_EVEN_PARITY; // TODO: Update when we add support for odd parity eigenvector files
-  eig_args.preserve_evals = ( first_solve || fabs(mass - previous_mass) < 1e-6 ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  eig_args.preserve_evals = QUDA_BOOLEAN_TRUE; // Default to preserving the eigenvalues
   eig_args.batched_rotate = param.eigen_param.batchedRotate;
   eig_args.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
   eig_args.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
@@ -395,9 +388,6 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
     printf("%s: Unrecognized eigensolver precision\n",myname);
     terminate(2);
   }
-
-  previous_mass = mass;
-  first_solve = false;
 
   qudaInvertMsrcDeflatable(MILC_PRECISION,
      quda_precision,

--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -155,7 +155,7 @@ int ks_congrad_parity_gpu(su3_vector *t_src, su3_vector *t_dest,
   eig_args.batched_rotate = param.eigen_param.batchedRotate;
   eig_args.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
   eig_args.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
-  eig_args.io_parity_inflate = QUDA_BOOLEAN_TRUE;
+  eig_args.io_parity_inflate = QUDA_BOOLEAN_FALSE;
   eig_args.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.tol_restart = param.eigen_param.tol_restart;
@@ -367,7 +367,7 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   eig_args.batched_rotate = param.eigen_param.batchedRotate;
   eig_args.save_prec = QUDA_SINGLE_PRECISION; // add to input parameters?
   eig_args.partfile = param.eigen_param.partfile ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
-  eig_args.io_parity_inflate = QUDA_BOOLEAN_TRUE;
+  eig_args.io_parity_inflate = QUDA_BOOLEAN_FALSE;
   eig_args.use_norm_op = ( parity == EVENANDODD ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.use_pc = ( parity != EVENANDODD) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_args.tol_restart = param.eigen_param.tol_restart;


### PR DESCRIPTION
This PR makes minor updates to `generic_ks/d_congrad5_fn_quda.c` to take advantage of the two-parity deflation now supported by the QUDA/MILC interface.

_I'm keeping this in draft status until the associated [QUDA PR](https://github.com/lattice/quda/pull/1590) is merged._