### PR TITLE
Fix QPhiX calls.

### DIFF
--- a/Make_template_combos
+++ b/Make_template_combos
@@ -335,11 +335,13 @@ ifeq ($(strip ${HAVE_FN_CG_GPU}),true)
     CONGRAD_FN_MILC = ${CONGRAD_FN_QUDA}
   else ifeq ($(strip ${HAVE_GRID}),true)
     CONGRAD_FN_MILC = ${CONGRAD_FN_GRID}
-  else ifeq ($(strip ${HAVE_QPHIX}),true)
-    CONGRAD_FN_MILC = ${CONGRAD_FN_QPHIX}
   endif
 else
-  CONGRAD_FN_MILC = ${CONGRAD_FN_MILC_CPU}
+  ifeq ($(strip ${HAVE_QPHIX}),true)
+    CONGRAD_FN_MILC = ${CONGRAD_FN_QPHIX}
+  else
+    CONGRAD_FN_MILC = ${CONGRAD_FN_MILC_CPU}
+  endif
 endif
 
 ######################################################################
@@ -373,15 +375,17 @@ endif
     ks_multicg_offset_qop_D.o  ks_multicg_offset_qop_F.o
 
 ifeq ($(strip ${HAVE_FN_CG_GPU}),true)
-ifeq ($(strip ${HAVE_QUDA}),true)
-  MULTI_INV_FN_MILC = ${MULTI_INV_FN_QUDA}
-else ifeq ($(strip ${HAVE_GRID}),true)
-  MULTI_INV_FN_MILC = ${MULTI_INV_FN_GRID}
-else ifeq ($(strip ${HAVE_QPHIX}),true)
-  MULTI_INV_FN_MILC = ${MULTI_INV_FN_QPHIX}
-endif
+  ifeq ($(strip ${HAVE_QUDA}),true)
+    MULTI_INV_FN_MILC = ${MULTI_INV_FN_QUDA}
+  else ifeq ($(strip ${HAVE_GRID}),true)
+    MULTI_INV_FN_MILC = ${MULTI_INV_FN_GRID}
+  endif
 else
-  MULTI_INV_FN_MILC = ${MULTI_INV_FN_MILC_CPU}
+  ifeq ($(strip ${HAVE_QPHIX}),true)
+    MULTI_INV_FN_MILC = ${MULTI_INV_FN_QPHIX}
+  else
+    MULTI_INV_FN_MILC = ${MULTI_INV_FN_MILC_CPU}
+  endif
 endif
 
 ######################################################################
@@ -484,7 +488,7 @@ endif
 
 # Standard MILC combinations
 
-  GAUGE_FORCE_MILC_CPU = gauge_force_imp.o gauge_stuff.o gauge_action_imp.o ranmom.o
+  GAUGE_FORCE_MILC_CPU = gauge_force_imp.o gauge_action_imp.o gauge_stuff.o ranmom.o
 
 # GPU support
 
@@ -492,11 +496,11 @@ endif
   
 # Standard QOP combinations
 
-  GAUGE_FORCE_QOP = gauge_force_symzk1_qop.o gauge_action_imp.o  gauge_stuff.o ranmom.o
+  GAUGE_FORCE_QOP = gauge_force_symzk1_qop.o gauge_action_imp.o gauge_stuff.o ranmom.o
 
 # Standard QPhiX combinations
 
-  GAUGE_FORCE_QPHIX = gauge_force_symzk1_qphix.o gauge_stuff.o ranmom.o \
+  GAUGE_FORCE_QPHIX = gauge_force_symzk1_qphix.o gauge_action_imp.o gauge_stuff.o ranmom.o \
     gauge_force_symzk1_qphix_D.o gauge_force_symzk1_qphix_F.o
 
 ifeq ($(strip ${HAVE_GF_GPU}),true)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ARCH ?= # epyc hsw skx clx icx spr knl pow8 pow9
 #----------------------------------------------------------------------
 # 2. Compiler family
 
-COMPILER ?= gnu # intel, ibm, cray-intel, rocm, nvhpc
+COMPILER ?= gnu # intel, intel-classic, ibm, cray-intel, rocm, nvhpc
 OFFLOAD ?= # cuda hip sycl openmp
 
 #----------------------------------------------------------------------
@@ -47,6 +47,16 @@ ifeq ($(strip ${COMPILER}),intel)
   else
     MY_CC  ?= icx
     MY_CXX ?= icpx
+  endif
+
+else ifeq ($(strip ${COMPILER}),intel-classic)
+
+  ifeq ($(strip ${MPP}),true)
+    MY_CC ?= mpicc
+    MY_CXX ?= mpicxx
+  else
+    MY_CC  ?= icc
+    MY_CXX ?= icpc
   endif
 
 else ifeq ($(strip ${COMPILER}),cray-intel)
@@ -177,7 +187,7 @@ ifeq ($(strip ${COMPILER}),ibm)
 
 endif
 
-#-------------- Intel icc/ecc -----------------------------------
+#-------------- Intel (OneAPI) icx/icpx -----------------------------------
 
 ifeq ($(strip ${COMPILER}),intel)
 
@@ -212,6 +222,44 @@ ifeq ($(strip ${COMPILER}),intel)
   LDFLAGS += ${ARCH_FLAG}
   OCFLAGS += -parallel-source-info=2 -debug inline-debug-info -fsave-optimization-record
   OCXXFLAGS += -parallel-source-info=2 -debug inline-debug-info -fsave-optimization-record
+
+  ifeq ($(strip ${OMP}),true)
+    OCFLAGS += -qopenmp
+    OCXXFLAGS += -qopenmp
+    LDFLAGS += -qopenmp
+  endif
+
+endif
+
+#-------------- Intel Classic icc/icpc -----------------------------------
+
+ifeq ($(strip ${COMPILER}),intel-classic)
+
+  OCFLAGS += -std=c99
+  OCXXFLAGS += -std=c++17
+
+  ifeq ($(strip ${ARCH}),knl)
+  ARCH_FLAG = -xMIC-AVX512
+  BINEXT=.knl
+  else ifeq ($(strip ${ARCH}),knc)
+  ARCH_FLAG = -mmic
+  BINEXT=.knc
+  else ifeq ($(strip ${ARCH}),skx)
+  ARCH_FLAG = -xCORE-AVX512 -qopt-zmm-usage=high
+  BINEXT=.skx
+  else ifeq ($(strip ${ARCH}),hsw)
+  ARCH_FLAG = -xCORE-AVX2
+  BINEXT=.hsw
+  else
+  ARCH_FLAG = -mavx
+  BINEXT=
+  endif
+
+  OCFLAGS += ${ARCH_FLAG}
+  OCXXFLAGS += ${ARCH_FLAG}
+  LDFLAGS += ${ARCH_FLAG}
+  OCFLAGS += -parallel-source-info=2 -debug inline-debug-info -qopt-report=5
+  OCXXFLAGS += -parallel-source-info=2 -debug inline-debug-info -qopt-report=5
 
   ifeq ($(strip ${OMP}),true)
     OCFLAGS += -qopenmp
@@ -400,6 +448,9 @@ WANT_APE_IO ?= # true
 ifeq ($(strip ${COMPILER}),intel)
   INCFFTW = -mkl
   LIBFFTW = -mkl
+else ifeq ($(strip ${COMPILER}),intel-classic)
+  INCFFTW = -mkl
+  LIBFFTW = -mkl
 else ifeq ($(strip ${COMPILER}),cray-intel)
   INCFFTW = -mkl
   LIBFFTW = -mkl
@@ -561,7 +612,7 @@ endif
 #----------------------------------------------------------------------
 # 16. QPhiX Options
 
-WANTQPHIX = #true
+WANTQPHIX ?= false
 WANT_FN_CG_QPHIX = true
 WANT_GF_QPHIX = true
 

--- a/include/imp_ferm_links.h
+++ b/include/imp_ferm_links.h
@@ -88,7 +88,6 @@ int ks_congrad_parity_cpu( su3_vector *t_src, su3_vector *t_dest,
 
 
 #ifdef USE_CG_GPU
-#if defined(HAVE_QUDA) || defined(HAVE_GRID) 
 
 #define ks_congrad_parity ks_congrad_parity_gpu
 #define ks_congrad_block_parity ks_congrad_block_parity_gpu
@@ -97,8 +96,6 @@ int ks_congrad_parity_cpu( su3_vector *t_src, su3_vector *t_dest,
 
 #define ks_congrad_parity ks_congrad_parity_qphix
 #define ks_congrad_block_parity ks_congrad_block_parity_qphix
-
-#endif
 
 #else
 
@@ -242,11 +239,9 @@ int ks_multicg_offset_field_qphix(	/* Return value is number of iterations taken
     );
 
 #ifdef USE_CG_GPU
-#if defined(HAVE_GRID) || defined(HAVE_QUDA)
 #define ks_multicg_offset_field ks_multicg_offset_field_gpu
 #elif USE_CG_QPHIX
 #define ks_multicg_offset_field ks_multicg_offset_field_qphix
-#endif
 #else
 #define ks_multicg_offset_field ks_multicg_offset_field_cpu
 #endif

--- a/libraries/Make_vanilla
+++ b/libraries/Make_vanilla
@@ -30,18 +30,22 @@ MAKEFILE = Make_vanilla
 
 ifeq ($(strip ${COMPILER}),intel)
   CC = icx
-else ifeq ($(strip ${COMPILER}),gnu)
-  CC = gcc
+else ifeq ($(strip ${COMPILER}),intel-classic)
+  CC = icc
 else ifeq ($(strip ${COMPILER}),cray-intel)
   CC = icc
+else ifeq ($(strip ${COMPILER}),gnu)
+  CC = gcc
 else ifeq ($(strip ${COMPILER}),ibm)
   CC = xlc_r
 else ifeq ($(strip ${COMPILER}),amdclang)
   CC = amdclang
+else ifeq ($(strip ${COMPILER}),nvhpc)
+  CC = nvc
 endif
 
 # Override
-CC = gcc # ( cc89 gcc xlc gcc pgcc cl g++ )
+# CC = gcc # ( cc89 gcc xlc gcc pgcc cl g++ )
 
 #----------------------------------------------------------------------
 # 2. Compiler optimization level
@@ -99,6 +103,24 @@ else ifeq ($(strip ${COMPILER}),intel)
 
   # Debugging and optimization
   OCFLAGS += #-parallel-source-info=2 -debug inline-debug-info -fsave-optimization-record
+
+else ifeq ($(strip ${COMPILER}),intel-classic)
+
+  # Architecture choices: knl, skx, clx, icx, knc, hsw
+  ifeq ($(strip ${ARCH}),knl)
+    OCFLAGS += -xMIC-AVX512
+  else ifeq ($(strip ${ARCH}),knc)
+    OCFLAGS += -mmic
+  else ifeq ($(strip ${ARCH}),skx)
+    OCFLAGS += -xCORE-AVX512 -qopt-zmm-usage=high
+  else ifeq ($(strip ${ARCH}),hsw)
+    OCFLAGS += -mavx2
+  else
+    OCFLAGS += -mavx
+  endif
+
+  # Debugging and optimization
+  OCFLAGS += #-parallel-source-info=2 -debug inline-debug-info -qopt-report=5
 
 endif
 

--- a/scidac/qinstall/Makefile
+++ b/scidac/qinstall/Makefile
@@ -1,10 +1,10 @@
 # Library versions and git branch tags
 
 QMPV= quda-1.1.0-consistent
-QMPT= 3010fef  
+QMPT= 3010fef
 
 QIOV= quda-1.1.0-consistent
-QIOT= a5c3ae580b846130c06dc060ab822f17d6fe2171
+QIOT= qio3-0-0
 
 QLAV= 1.9.0
 QLAT= qla1-9-0


### PR DESCRIPTION
Also:
- Add `intel-classic` compiler (`icc`/`icpc`).
- Update QIO commit to match QUDA develop branch.
- Don't overwrite `CC = gcc` in libraries/Make_vanilla.