### PR TITLE
Fix mixed precision handling for MRHS solver

### DIFF
--- a/generic_ks/d_congrad5_fn_quda.c
+++ b/generic_ks/d_congrad5_fn_quda.c
@@ -313,7 +313,9 @@ int ks_congrad_block_parity_gpu(int nsrc, su3_vector **t_src, su3_vector **t_des
   }
 
   inv_args.max_iter = qic->max*qic->nrestart;
-#if defined(MAX_MIXED) || defined(HALF_MIXED)
+#if defined(MAX_MIXED)
+  inv_args.mixed_precision = 2;
+#elif defined(HALF_MIXED)
   inv_args.mixed_precision = 1;
 #else
   inv_args.mixed_precision = 0;


### PR DESCRIPTION
In the current develop branch in `generic_ks/d_congrad5_fn_quda.c`, mixed precision in the non-block solver is set as:
```
#if defined(MAX_MIXED)
  inv_args.mixed_precision = 2;
#elif defined(HALF_MIXED)
  inv_args.mixed_precision = 1;
#else
  inv_args.mixed_precision = 0;
#endif
```
However, in the block solver, it is:
```
#if defined(MAX_MIXED) || defined(HALF_MIXED)
  inv_args.mixed_precision = 1;
#else
  inv_args.mixed_precision = 0;
#endif
```
For the block solver, this results in sloppy single precision when requesting `MAX_MIXED` instead of sloppy half precision. I don't know why the precision was set this way for the block solver, but it has a significant negative effect on the performance of MRHS solves because it effectively does not allow the block solver to run with full mixed precision. The performance effect is so bad that it's currently generally better to run without MRHS.

This PR fixes it. I note also that the newer branch `feature/quda-exact-current` where this file is updated already has this fix. But I am implementing the fix here in the `develop` branch since this branch/solver is currently used, and we are not yet ready to merge `feature/quda-exact-current` into `develop`.