### PR TITLE
fix: add buffer-length check in setup.c

### DIFF
--- a/hvy_qpot/setup.c
+++ b/hvy_qpot/setup.c
@@ -157,9 +157,9 @@ int readin(int prompt){
 #endif
     startflag = par_buf.startflag;
     saveflag = par_buf.saveflag;
-    strcpy(startfile,par_buf.startfile);
-    strcpy(savefile,par_buf.savefile);
-    strcpy(stringLFN, par_buf.stringLFN);
+    snprintf(startfile,MAXFILENAME,"%s",par_buf.startfile);
+    snprintf(savefile,MAXFILENAME,"%s",par_buf.savefile);
+    snprintf(stringLFN,MAXFILENAME,"%s",par_buf.stringLFN);
 
     /* Do whatever is needed to get lattice */
 	if( startflag != CONTINUE )


### PR DESCRIPTION
## Summary
Fix high severity security issue in `hvy_qpot/setup.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `hvy_qpot/setup.c:160` |
| **Assessment** | Confirmed exploitable |
| **CWE** | CWE-120 |

**Description**: Three strcpy calls copy user-supplied configuration parameters (startfile, savefile, stringLFN) from par_buf into destination buffers without bounds checking. If the source strings exceed the destination buffer sizes, a stack buffer overflow occurs that could overwrite return addresses or function pointers.

## Changes
- `hvy_qpot/setup.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
